### PR TITLE
fix: invalid winui usings on uwp build

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ This engine uses the MSTest attributes to perform the discovery of tests.
 This package is built as a source package. It includes XAML files and cs files into the referencing project, making it independent from the Uno.UI version used by your project. It is built in such a way that Uno.UI itself can use this package while not referencing itself through nuget packages dependencies.
 
 ## Using the Runtime Tests Engine
-- Add the Uno.UI.RuntimeTests.Engine nuget package to your application
-- Add the following xaml to your application:
-    ```xaml
-    <Page .... xmlns:runtimetests="using:Uno.UI.RuntimeTests">
+- Add the [`Uno.UI.RuntimeTests.Engine`](https://www.nuget.org/packages/Uno.UI.RuntimeTests.Engine/) nuget package to the head projects.
+- Add the following xaml to a page in your application:
+    ```xml
+    <Page xmlns:runtimetests="using:Uno.UI.RuntimeTests" ...>
         <runtimetests:UnitTestsControl />
     </Page>
     ```
@@ -29,7 +29,7 @@ This package is built as a source package. It includes XAML files and cs files i
     ```
     note: This should not be added to the Windows head project of an `unoapp-uwp` (UWP) solution.
 
-The test control will appear on your screen.
+The test control will appear on that page.
 
 Write your tests as follows:
 ```csharp
@@ -55,12 +55,16 @@ Placing this attribute on a test will switch the rendering of the test render zo
 Placing this attribute on a test or test class will force the tests to run on the dispatcher. By default, tests run off of the dispatcher.
 
 ### InjectedPointerAttribute
-This attribute configures the type of the pointer that is simulated when using helpers like `App.TapCoordinates()`. You can define the attribute more than once, the test will then be run for each configured type. When not defined, the test engine will use the common pointer type of the platfrom (touch for mobile OS like iOS and Android, mouse for browsers, skia and other desktop platforms).
+This attribute configures the type of the pointer that is simulated when using helpers like `App.TapCoordinates()`. You can define the attribute more than once, the test will then be run for each configured type. When not defined, the test engine will use the common pointer type of the platform (touch for mobile OS like iOS and Android, mouse for browsers, skia and other desktop platforms).
 
 ## Placing tests in a separate assembly
 - In a separate assembly, add the following attributes code:
     ```csharp
+    using System;
+    using Windows.Devices.Input;
+
     namespace Uno.UI.RuntimeTests;
+
     public sealed class RequiresFullWindowAttribute : Attribute { }
 
     public sealed class RunsOnUIThreadAttribute : Attribute { }
@@ -79,9 +83,9 @@ This attribute configures the type of the pointer that is simulated when using h
 - Then define the following in your `csproj`:
    ```xml
     <PropertyGroup>
-    	<DefineConstants>$(DefineConstants);UNO_RUNTIMETESTS_DISABLE_INJECTEDPOINTERATTRIBUTE</DefineConstants>
-    	<DefineConstants>$(DefineConstants);UNO_RUNTIMETESTS_DISABLE_REQUIRESFULLWINDOWATTRIBUTE</DefineConstants>
-    	<DefineConstants>$(DefineConstants);UNO_RUNTIMETESTS_DISABLE_RUNSONUITHREADATTRIBUTE</DefineConstants>
+        <DefineConstants>$(DefineConstants);UNO_RUNTIMETESTS_DISABLE_INJECTEDPOINTERATTRIBUTE</DefineConstants>
+        <DefineConstants>$(DefineConstants);UNO_RUNTIMETESTS_DISABLE_REQUIRESFULLWINDOWATTRIBUTE</DefineConstants>
+        <DefineConstants>$(DefineConstants);UNO_RUNTIMETESTS_DISABLE_RUNSONUITHREADATTRIBUTE</DefineConstants>
     </PropertyGroup>
    ```
 

--- a/README.md
+++ b/README.md
@@ -21,12 +21,13 @@ This package is built as a source package. It includes XAML files and cs files i
         <runtimetests:UnitTestsControl />
     </Page>
     ```
-- In the uwp/winui head project, add the following:
+- For `unoapp` (WinUI) solution only, add the following to the Windows head project:
     ```xml
     <PropertyGroup>
-    	<DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
+        <DefineConstants>$(DefineConstants);WINDOWS_WINUI</DefineConstants>
     </PropertyGroup>
     ```
+    note: This should not be added to the Windows head project of an `unoapp-uwp` (UWP) solution.
 
 The test control will appear on your screen.
 

--- a/src/Uno.UI.RuntimeTests.Engine.Library/UnitTestsControl.cs
+++ b/src/Uno.UI.RuntimeTests.Engine.Library/UnitTestsControl.cs
@@ -1,22 +1,22 @@
-#nullable enable
+﻿#nullable enable
 
 using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices.WindowsRuntime;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Extensions.Logging;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Storage;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Text;
-using System.Security.Cryptography;
-using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
 #if HAS_UNO
@@ -29,13 +29,15 @@ using Windows.UI;
 using Windows.UI.Core;
 using Windows.UI.Text;
 using Windows.UI.ViewManagement;
+using Microsoft.UI.Text;
+using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Documents;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Text;
-using Microsoft.UI;
+
+using _DispatcherQueueHandler = Microsoft.UI.Dispatching.DispatcherQueueHandler;
 #else
 using Windows.UI;
 using Windows.UI.Core;
@@ -46,6 +48,8 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Documents;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
+
+using _DispatcherQueueHandler = Windows.UI.Core.DispatchedHandler;
 #endif
 
 namespace Uno.UI.RuntimeTests;
@@ -273,7 +277,7 @@ public sealed partial class UnitTestsControl : UserControl
             }
         }
 
-        await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, Setter);
+        await RunOnDispatcherAsync(Setter);
     }
 
     private void ReportTestsResults()
@@ -286,7 +290,7 @@ public sealed partial class UnitTestsControl : UserControl
             FailedTestCountForUITest = failedTestCount.Text = _currentRun?.Failed.ToString() ?? "<no current run>";
         }
 
-        var t = Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, Update);
+        RunOnDispatcher(Update);
     }
 
     private async Task GenerateTestResults()
@@ -301,30 +305,27 @@ public sealed partial class UnitTestsControl : UserControl
             }
         }
 
-        await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, Update);
+        await RunOnDispatcherAsync(Update);
     }
 
     private void ReportTestClass(TypeInfo testClass)
     {
-        var t = Dispatcher.RunAsync(
-            Windows.UI.Core.CoreDispatcherPriority.Normal,
-            () =>
+        RunOnDispatcher(() =>
+        {
+            if (!IsRunningOnCI)
             {
-                if (!IsRunningOnCI)
+                var testResultBlock = new TextBlock()
                 {
-                    var testResultBlock = new TextBlock()
-                    {
-                        Text = $"{testClass.Name} ({testClass.Assembly.GetName().Name})",
-                        Foreground = new SolidColorBrush(Colors.White),
-                        FontSize = 16d,
-                        IsTextSelectionEnabled = true
-                    };
+                    Text = $"{testClass.Name} ({testClass.Assembly.GetName().Name})",
+                    Foreground = new SolidColorBrush(Colors.White),
+                    FontSize = 16d,
+                    IsTextSelectionEnabled = true
+                };
 
-                    testResults.Children.Add(testResultBlock);
-                    testResultBlock.StartBringIntoView();
-                }
+                testResults.Children.Add(testResultBlock);
+                testResultBlock.StartBringIntoView();
             }
-        );
+        });
     }
 
     private void ReportTestResult(string testName, TimeSpan duration, TestResult testResult, Exception? error = null, string? message = null, string? console = null)
@@ -408,9 +409,7 @@ public sealed partial class UnitTestsControl : UserControl
             }
         }
 
-        var t = Dispatcher.RunAsync(
-            Windows.UI.Core.CoreDispatcherPriority.Normal,
-            Update);
+        RunOnDispatcher(Update);
     }
 
     private static string GenerateNUnitTestResults(List<TestCaseResult> testCases, TestRun testRun)
@@ -620,7 +619,7 @@ public sealed partial class UnitTestsControl : UserControl
         }
         finally
         {
-            await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            await RunOnDispatcherAsync(() =>
             {
                 testFilter.IsEnabled = runButton.IsEnabled = true; // Disable the testFilter to avoid SIP to re-open
                 testResults.Visibility = Visibility.Visible;
@@ -669,7 +668,7 @@ public sealed partial class UnitTestsControl : UserControl
         }
         finally
         {
-            await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            await RunOnDispatcherAsync(() =>
             {
                 testFilter.IsEnabled = runButton.IsEnabled = true; // Disable the testFilter to avoid SIP to re-open
                 if (!IsRunningOnCI)
@@ -786,7 +785,7 @@ public sealed partial class UnitTestsControl : UserControl
                     {
                         if (test.RequiresFullWindow)
                         {
-                            await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+                            await RunOnDispatcherAsync(() =>
                             {
 #if __ANDROID__
 								// Hide the systray!
@@ -799,7 +798,7 @@ public sealed partial class UnitTestsControl : UserControl
                             });
                             cleanupActions.Add(async _ =>
                             {
-                                await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+                                await RunOnDispatcherAsync(() =>
                                 {
 #if __ANDROID__
 									// Restore the systray!
@@ -815,7 +814,7 @@ public sealed partial class UnitTestsControl : UserControl
                         object? returnValue = null;
                         if (test.RunsOnUIThread)
                         {
-                            await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+                            await RunOnDispatcherAsync(() =>
                             {
                                 // UNO MOVE
                                 // if (instance is IInjectPointers pointersInjector)
@@ -967,7 +966,7 @@ public sealed partial class UnitTestsControl : UserControl
 
             if (runsOnUIThread)
             {
-                await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, Run);
+                await RunOnDispatcherAsync(Run);
             }
             else
             {
@@ -1055,5 +1054,33 @@ public sealed partial class UnitTestsControl : UserControl
         data.SetText(NUnitTestResultsDocument);
 
         Clipboard.SetContent(data);
+    }
+
+    private Task RunOnDispatcherAsync(_DispatcherQueueHandler callback)
+    {
+        var tcs = new TaskCompletionSource<object>();
+        RunOnDispatcher(() =>
+        {
+            try
+            {
+                callback();
+                tcs.TrySetResult(default!);
+            }
+            catch(Exception e)
+            {
+                tcs.TrySetException(e);
+            }
+        });
+
+        return tcs.Task;
+    }
+
+    private void RunOnDispatcher(_DispatcherQueueHandler callback)
+    {
+#if HAS_UNO_WINUI || WINDOWS_WINUI
+        this.DispatcherQueue.TryEnqueue(callback);
+#else
+        _ = this.Dispatcher.RunAsync(global::Windows.UI.Core.CoreDispatcherPriority.Normal, callback);
+#endif
     }
 }

--- a/src/Uno.UI.RuntimeTests.Engine.Library/UnitTestsControl.cs
+++ b/src/Uno.UI.RuntimeTests.Engine.Library/UnitTestsControl.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -24,7 +24,7 @@ using Uno.Foundation.Logging;
 using Uno.Logging;
 #endif
 
-#if HAS_UNO_WINUI || WINDOWS
+#if HAS_UNO_WINUI || WINDOWS_WINUI
 using Windows.UI;
 using Windows.UI.Core;
 using Windows.UI.Text;

--- a/src/Uno.UI.RuntimeTests.Engine/Uno.UI.RuntimeTests.Engine.Shared/SanityTests.cs
+++ b/src/Uno.UI.RuntimeTests.Engine/Uno.UI.RuntimeTests.Engine.Shared/SanityTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Uno.UI.RuntimeTests.Engine
+{
+	[TestClass]
+	public class SanityTests
+	{
+		[TestMethod]
+		public void Is_Sane()
+		{
+		}
+
+		[TestMethod]
+		public async Task Is_Still_Sane()
+		{
+			await Task.Delay(2000);
+		}
+
+#if DEBUG
+		[TestMethod]
+		public async Task No_Longer_Sane() // expected to fail
+		{
+			await Task.Delay(2000);
+
+			throw new Exception("Great works require a touch of insanity.");
+		}
+
+		[TestMethod, Ignore]
+		public void Is_An_Illusion() // expected to be ignored
+		{
+		}
+#endif
+	}
+}

--- a/src/Uno.UI.RuntimeTests.Engine/Uno.UI.RuntimeTests.Engine.Windows/Uno.UI.RuntimeTests.Engine.Windows.csproj
+++ b/src/Uno.UI.RuntimeTests.Engine/Uno.UI.RuntimeTests.Engine.Windows/Uno.UI.RuntimeTests.Engine.Windows.csproj
@@ -10,7 +10,8 @@
 		<PublishProfile>win10-$(Platform).pubxml</PublishProfile>
 		<UseWinUI>true</UseWinUI>
 		<EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
-		<DefineConstants>WINDOWS</DefineConstants>
+
+		<DefineConstants>WINDOWS_WINUI</DefineConstants>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): n/a

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
- invalid winui usings are used for uwp-desktop head build following the read-me instructions
- DependencyObject::Dispatcher is not implemented/supported/defined on winui, as a result attempting to access its member is an automatic NullReferenceException on winui.

## What is the new behavior?
^ fixed

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)