### PR TITLE
fix: duplicated tests

### DIFF
--- a/src/Uno.UI.RuntimeTests.Engine.Library/UnitTestsControl.cs
+++ b/src/Uno.UI.RuntimeTests.Engine.Library/UnitTestsControl.cs
@@ -966,13 +966,11 @@ public sealed partial class UnitTestsControl : UserControl
 
 	private IEnumerable<UnitTestClassInfo> InitializeTests()
 	{
-		var testAssembliesTypes =
-			from asm in AppDomain.CurrentDomain.GetAssemblies()
-			where asm.GetName()?.Name?.EndsWith("tests", StringComparison.OrdinalIgnoreCase) ?? false
-			from type in asm.GetTypes()
-			select type;
-
-		var types = GetType().GetTypeInfo().Assembly.GetTypes().Concat(testAssembliesTypes);
+		var testAssemblies = AppDomain.CurrentDomain.GetAssemblies()
+			.Where(x => x.GetName()?.Name?.EndsWith("Tests", StringComparison.OrdinalIgnoreCase) ?? false)
+			.Concat(new[] { GetType().GetTypeInfo().Assembly })
+			.Distinct();
+		var types = testAssemblies.SelectMany(x => x.GetTypes());
 
 		if (_ciTestGroupCache != -1)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): close #60

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
when using a separate assembly for tests and said assembly name ends with "tests", the tests are run twice.

## What is the new behavior?
^no more

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)