### PR TITLE
chore: Update logging to .net 7 (to get latest nullable annotations)

### DIFF
--- a/src/TestApp/uwp/Uno.UI.RuntimeTests.Engine.Mobile/Uno.UI.RuntimeTests.Engine.Mobile.csproj
+++ b/src/TestApp/uwp/Uno.UI.RuntimeTests.Engine.Mobile/Uno.UI.RuntimeTests.Engine.Mobile.csproj
@@ -25,7 +25,7 @@
 		<PackageReference Include="Uno.UI" Version="5.0.0-dev.3552" />
 		<PackageReference Include="Uno.UI.DevServer" Version="5.0.0-dev.3552" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.0.0-dev.3552" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
 
 		<PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
 	</ItemGroup>

--- a/src/TestApp/uwp/Uno.UI.RuntimeTests.Engine.Skia.Gtk/Uno.UI.RuntimeTests.Engine.Skia.Gtk.csproj
+++ b/src/TestApp/uwp/Uno.UI.RuntimeTests.Engine.Skia.Gtk/Uno.UI.RuntimeTests.Engine.Skia.Gtk.csproj
@@ -15,7 +15,7 @@
 		<UpToDateCheckInput Include="..\..\shared\**\*.xaml" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
 		<PackageReference Include="Uno.UI.Skia.Gtk" Version="5.0.0-dev.3552" />
 		<PackageReference Include="Uno.UI.DevServer" Version="5.0.0-dev.3552" /><!--Note: Keep the DevServer package also in release for hot reload tests (cf. HotReloadHelper).-->
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.0.0-dev.3552" />

--- a/src/TestApp/uwp/Uno.UI.RuntimeTests.Engine.Skia.Linux.FrameBuffer/Uno.UI.RuntimeTests.Engine.Skia.Linux.FrameBuffer.csproj
+++ b/src/TestApp/uwp/Uno.UI.RuntimeTests.Engine.Skia.Linux.FrameBuffer/Uno.UI.RuntimeTests.Engine.Skia.Linux.FrameBuffer.csproj
@@ -15,7 +15,7 @@
 		<UpToDateCheckInput Include="..\..\shared\**\*.xaml" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
 		<PackageReference Include="Uno.UI.Skia.Linux.FrameBuffer" Version="5.0.0-dev.3552" />
 		<PackageReference Include="Uno.UI.DevServer" Version="5.0.0-dev.3552" /><!--Note: Keep the DevServer package also in release for hot reload tests (cf. HotReloadHelper).-->
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.0.0-dev.3552" />

--- a/src/TestApp/uwp/Uno.UI.RuntimeTests.Engine.Skia.WPF/Uno.UI.RuntimeTests.Engine.Skia.WPF.csproj
+++ b/src/TestApp/uwp/Uno.UI.RuntimeTests.Engine.Skia.WPF/Uno.UI.RuntimeTests.Engine.Skia.WPF.csproj
@@ -19,7 +19,7 @@
 		</AssemblyAttribute>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
 		<PackageReference Include="Uno.UI.Skia.Wpf" Version="5.0.0-dev.3552" />
 		<PackageReference Include="Uno.UI.DevServer" Version="5.0.0-dev.3552"/><!--Note: Keep the DevServer package also in release for hot reload tests (cf. HotReloadHelper).-->
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.0.0-dev.3552" />

--- a/src/TestApp/uwp/Uno.UI.RuntimeTests.Engine.UWP/Uno.UI.RuntimeTests.Engine.Uwp.csproj
+++ b/src/TestApp/uwp/Uno.UI.RuntimeTests.Engine.UWP/Uno.UI.RuntimeTests.Engine.Uwp.csproj
@@ -10,11 +10,11 @@
 			-->
       <Version>6.2.11</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
     <PackageReference Include="Microsoft.UI.Xaml" Version="2.6.2" />
     <PackageReference Include="Uno.UI" Version="4.6.19" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
     <PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
   </ItemGroup>
   <PropertyGroup>

--- a/src/TestApp/uwp/Uno.UI.RuntimeTests.Engine.Wasm/Uno.UI.RuntimeTests.Engine.Wasm.csproj
+++ b/src/TestApp/uwp/Uno.UI.RuntimeTests.Engine.Wasm/Uno.UI.RuntimeTests.Engine.Wasm.csproj
@@ -42,7 +42,7 @@
 		<None Include="wwwroot\web.config" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
 		<PackageReference Include="Uno.UI.WebAssembly" Version="5.0.0-dev.3552" />
 		<PackageReference Include="Uno.UI.DevServer" Version="5.0.0-dev.3552" Condition="'$(Configuration)'=='Debug'" />

--- a/src/TestApp/winui/Uno.UI.RuntimeTests.Engine.Mobile/Uno.UI.RuntimeTests.Engine.Mobile.csproj
+++ b/src/TestApp/winui/Uno.UI.RuntimeTests.Engine.Mobile/Uno.UI.RuntimeTests.Engine.Mobile.csproj
@@ -21,7 +21,7 @@
 		<PackageReference Include="Uno.WinUI" Version="5.0.0-dev.3552" />
 		<PackageReference Include="Uno.WinUI.DevServer" Version="5.0.0-dev.3552" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.0.0-dev.3552" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
 
 		<PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
 	</ItemGroup>

--- a/src/TestApp/winui/Uno.UI.RuntimeTests.Engine.Skia.Gtk/Uno.UI.RuntimeTests.Engine.Skia.Gtk.csproj
+++ b/src/TestApp/winui/Uno.UI.RuntimeTests.Engine.Skia.Gtk/Uno.UI.RuntimeTests.Engine.Skia.Gtk.csproj
@@ -15,7 +15,7 @@
 		<UpToDateCheckInput Include="..\..\shared\**\*.xaml" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
 		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="5.0.0-dev.3552" />
 		<PackageReference Include="Uno.WinUI.DevServer" Version="5.0.0-dev.3552" /><!--Note: Keep the DevServer package also in release for hot reload tests (cf. HotReloadHelper).-->
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.0.0-dev.3552" />

--- a/src/TestApp/winui/Uno.UI.RuntimeTests.Engine.Skia.Linux.FrameBuffer/Uno.UI.RuntimeTests.Engine.Skia.Linux.FrameBuffer.csproj
+++ b/src/TestApp/winui/Uno.UI.RuntimeTests.Engine.Skia.Linux.FrameBuffer/Uno.UI.RuntimeTests.Engine.Skia.Linux.FrameBuffer.csproj
@@ -15,7 +15,7 @@
 		<UpToDateCheckInput Include="..\..\shared\**\*.xaml" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
 		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="5.0.0-dev.3552" />
 		<PackageReference Include="Uno.WinUI.DevServer" Version="5.0.0-dev.3552" /><!--Note: Keep the DevServer package also in release for hot reload tests (cf. HotReloadHelper).-->
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.0.0-dev.3552" />

--- a/src/TestApp/winui/Uno.UI.RuntimeTests.Engine.Skia.Wpf/Uno.UI.RuntimeTests.Engine.Skia.Wpf.csproj
+++ b/src/TestApp/winui/Uno.UI.RuntimeTests.Engine.Skia.Wpf/Uno.UI.RuntimeTests.Engine.Skia.Wpf.csproj
@@ -19,7 +19,7 @@
 		</AssemblyAttribute>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
 		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="5.0.0-dev.3552" />
 		<PackageReference Include="Uno.WinUI.DevServer" Version="5.0.0-dev.3552" /><!--Note: Keep the DevServer package also in release for hot reload tests (cf. HotReloadHelper).-->
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.0.0-dev.3552" />

--- a/src/TestApp/winui/Uno.UI.RuntimeTests.Engine.Wasm/Uno.UI.RuntimeTests.Engine.Wasm.csproj
+++ b/src/TestApp/winui/Uno.UI.RuntimeTests.Engine.Wasm/Uno.UI.RuntimeTests.Engine.Wasm.csproj
@@ -42,7 +42,7 @@
 		<None Include="wwwroot\web.config" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
 		<PackageReference Include="Uno.WinUI.WebAssembly" Version="5.0.0-dev.3552" />
 		<PackageReference Include="Uno.WinUI.DevServer" Version="5.0.0-dev.3552" Condition="'$(Configuration)'=='Debug'" />

--- a/src/TestApp/winui/Uno.UI.RuntimeTests.Engine.Windows/Uno.UI.RuntimeTests.Engine.Windows.csproj
+++ b/src/TestApp/winui/Uno.UI.RuntimeTests.Engine.Windows/Uno.UI.RuntimeTests.Engine.Windows.csproj
@@ -26,7 +26,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.3" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.196" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
 
 		<PackageReference Include="MSTest.TestFramework" Version="2.2.10" />

--- a/src/Uno.UI.RuntimeTests.Engine.Library/Engine/ExternalRunner/_Private/DevServer.cs
+++ b/src/Uno.UI.RuntimeTests.Engine.Library/Engine/ExternalRunner/_Private/DevServer.cs
@@ -45,7 +45,7 @@ internal sealed partial class DevServer : IAsyncDisposable
 	public static async Task<DevServer> Start(CancellationToken ct)
 	{
 #if !HAS_UNO_DEVSERVER
-		throw new NotSupportedException("Dev server is not supported on this platform.");
+		throw new NotSupportedException("Dev server has not been referenced.");
 #else
 		var path = await GetDevServer(ct);
 		var port = GetTcpPort();

--- a/src/Uno.UI.RuntimeTests.Engine.Library/Engine/ExternalRunner/_Private/LogScope.cs
+++ b/src/Uno.UI.RuntimeTests.Engine.Library/Engine/ExternalRunner/_Private/LogScope.cs
@@ -1,4 +1,9 @@
 ﻿#if !UNO_RUNTIMETESTS_DISABLE_UI
+
+#if !IS_UNO_RUNTIMETEST_PROJECT
+#pragma warning disable
+#endif
+
 using System;
 using System.Linq;
 using Microsoft.Extensions.Logging;
@@ -42,7 +47,8 @@ internal readonly struct LogScope : IDisposable, ILogger
 		=> _logger.IsEnabled(logLevel);
 
 	/// <inheritdoc />
-	public IDisposable BeginScope<TState>(TState state)
+	public IDisposable? BeginScope<TState>(TState state)
+		where TState : notnull
 		=> _logger.BeginScope(state);
 
 	/// <inheritdoc />


### PR DESCRIPTION
## Bugfix
Update logging to .net 7 (to get latest nullable annotations)

## What is the current behavior?
Build fails in apps if using last version of MS logging and warning as errro 

## What is the new behavior?
No more warning ... and warning disabled in apps

## PR Checklist
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
