### PR TITLE
feat: Make runtime tests engine more global using friendly

### DIFF
--- a/src/Uno.UI.RuntimeTests.Engine.Library/Library/Helpers/AsyncAssert.cs
+++ b/src/Uno.UI.RuntimeTests.Engine.Library/Library/Helpers/AsyncAssert.cs
@@ -3,15 +3,6 @@
 #pragma warning disable
 #endif
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-
 namespace Uno.UI.RuntimeTests;
 
 public static partial class AsyncAssert
@@ -25,13 +16,13 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="conditionExpression">For debug purposes.</param>
-	public static ValueTask IsTrue(
-		Func<bool> condition,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("condition")] string conditionExpression = "")
-		=> IsTrueCore(condition, $"{conditionExpression} to be true but found false ({Path.GetFileName(file)}@{line})", TestHelper.DefaultTimeout, ct);
+	public static global::System.Threading.Tasks.ValueTask IsTrue(
+		global::System.Func<bool> condition,
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("condition")] string conditionExpression = "")
+		=> IsTrueCore(condition, $"{conditionExpression} to be true but found false ({(global::System.IO.Path.GetFileName(file))}@{line})", TestHelper.DefaultTimeout, ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified condition is true and throws an exception if the condition is false.
@@ -42,14 +33,14 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="conditionExpression">For debug purposes.</param>
-	public static ValueTask IsTrue(
-		Func<bool> condition,
-		TimeSpan timeout,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("condition")] string conditionExpression = "")
-		=> IsTrueCore(condition, $"{conditionExpression} to be true but found false ({Path.GetFileName(file)}@{line})", timeout, ct);
+	public static global::System.Threading.Tasks.ValueTask IsTrue(
+		global::System.Func<bool> condition,
+		global::System.TimeSpan timeout,
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("condition")] string conditionExpression = "")
+		=> IsTrueCore(condition, $"{conditionExpression} to be true but found false ({(global::System.IO.Path.GetFileName(file))}@{line})", timeout, ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified condition is true and throws an exception if the condition is false.
@@ -60,14 +51,14 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="conditionExpression">For debug purposes.</param>
-	public static ValueTask IsTrue(
-		Func<bool> condition,
+	public static global::System.Threading.Tasks.ValueTask IsTrue(
+		global::System.Func<bool> condition,
 		int timeoutMs,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("condition")] string conditionExpression = "")
-		=> IsTrueCore(condition, $"{conditionExpression} to be true but found false ({Path.GetFileName(file)}@{line})", TimeSpan.FromMilliseconds(timeoutMs), ct);
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("condition")] string conditionExpression = "")
+		=> IsTrueCore(condition, $"{conditionExpression} to be true but found false ({(global::System.IO.Path.GetFileName(file))}@{line})", global::System.TimeSpan.FromMilliseconds(timeoutMs), ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified condition is true and throws an exception if the condition is false.
@@ -75,7 +66,7 @@ public static partial class AsyncAssert
 	/// <param name="condition">The condition the test expects to be true.</param>
 	/// <param name="message">The message to include in the exception when condition is not equal to expected. The message is shown in test results.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask IsTrue(Func<bool> condition, string message, CancellationToken ct = default)
+	public static global::System.Threading.Tasks.ValueTask IsTrue(global::System.Func<bool> condition, string message, global::System.Threading.CancellationToken ct = default)
 		=> IsTrueCore(condition, message, TestHelper.DefaultTimeout, ct);
 
 	/// <summary>
@@ -85,7 +76,7 @@ public static partial class AsyncAssert
 	/// <param name="message">The message to include in the exception when condition is not equal to expected. The message is shown in test results.</param>
 	/// <param name="timeout">The max duration to wait for.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask IsTrue(Func<bool> condition, string message, TimeSpan timeout, CancellationToken ct = default)
+	public static global::System.Threading.Tasks.ValueTask IsTrue(global::System.Func<bool> condition, string message, global::System.TimeSpan timeout, global::System.Threading.CancellationToken ct = default)
 		=> IsTrueCore(condition, message, timeout, ct);
 
 	/// <summary>
@@ -95,8 +86,8 @@ public static partial class AsyncAssert
 	/// <param name="message">The message to include in the exception when condition is not equal to expected. The message is shown in test results.</param>
 	/// <param name="timeoutMs">The max duration to wait for in milliseconds.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask IsTrue(Func<bool> condition, string message, int timeoutMs, CancellationToken ct = default)
-		=> IsTrueCore( condition, message, TimeSpan.FromMilliseconds(timeoutMs), ct);
+	public static global::System.Threading.Tasks.ValueTask IsTrue(global::System.Func<bool> condition, string message, int timeoutMs, global::System.Threading.CancellationToken ct = default)
+		=> IsTrueCore( condition, message, global::System.TimeSpan.FromMilliseconds(timeoutMs), ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified condition is true and throws an exception if the condition is false.
@@ -106,13 +97,13 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="conditionExpression">For debug purposes.</param>
-	public static ValueTask IsTrue(
-		Func<ValueTask<bool>> condition,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("condition")] string conditionExpression = "")
-		=> IsTrueCore(condition, $"{conditionExpression} to be true but found false ({Path.GetFileName(file)}@{line})", TestHelper.DefaultTimeout, ct);
+	public static global::System.Threading.Tasks.ValueTask IsTrue(
+		global::System.Func<global::System.Threading.Tasks.ValueTask<bool>> condition,
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("condition")] string conditionExpression = "")
+		=> IsTrueCore(condition, $"{conditionExpression} to be true but found false ({(global::System.IO.Path.GetFileName(file))}@{line})", TestHelper.DefaultTimeout, ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified condition is true and throws an exception if the condition is false.
@@ -123,14 +114,14 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="conditionExpression">For debug purposes.</param>
-	public static ValueTask IsTrue(
-		Func<ValueTask<bool>> condition,
-		TimeSpan timeout,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("condition")] string conditionExpression = "")
-		=> IsTrueCore(condition, $"{conditionExpression} to be true but found false ({Path.GetFileName(file)}@{line})", timeout, ct);
+	public static global::System.Threading.Tasks.ValueTask IsTrue(
+		global::System.Func<global::System.Threading.Tasks.ValueTask<bool>> condition,
+		global::System.TimeSpan timeout,
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("condition")] string conditionExpression = "")
+		=> IsTrueCore(condition, $"{conditionExpression} to be true but found false ({(global::System.IO.Path.GetFileName(file))}@{line})", timeout, ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified condition is true and throws an exception if the condition is false.
@@ -141,14 +132,14 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="conditionExpression">For debug purposes.</param>
-	public static ValueTask IsTrue(
-		Func<ValueTask<bool>> condition,
+	public static global::System.Threading.Tasks.ValueTask IsTrue(
+		global::System.Func<global::System.Threading.Tasks.ValueTask<bool>> condition,
 		int timeoutMs,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("condition")] string conditionExpression = "")
-		=> IsTrueCore(condition, $"{conditionExpression} to be true but found false ({Path.GetFileName(file)}@{line})", TimeSpan.FromMilliseconds(timeoutMs), ct);
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("condition")] string conditionExpression = "")
+		=> IsTrueCore(condition, $"{conditionExpression} to be true but found false ({(global::System.IO.Path.GetFileName(file))}@{line})", global::System.TimeSpan.FromMilliseconds(timeoutMs), ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified condition is true and throws an exception if the condition is false.
@@ -156,7 +147,7 @@ public static partial class AsyncAssert
 	/// <param name="condition">The condition the test expects to be true.</param>
 	/// <param name="message">The message to include in the exception when condition is not equal to expected. The message is shown in test results.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask IsTrue(Func<ValueTask<bool>> condition, string message, CancellationToken ct = default)
+	public static global::System.Threading.Tasks.ValueTask IsTrue(global::System.Func<global::System.Threading.Tasks.ValueTask<bool>> condition, string message, global::System.Threading.CancellationToken ct = default)
 		=> IsTrueCore(condition, message, TestHelper.DefaultTimeout, ct);
 
 	/// <summary>
@@ -166,7 +157,7 @@ public static partial class AsyncAssert
 	/// <param name="message">The message to include in the exception when condition is not equal to expected. The message is shown in test results.</param>
 	/// <param name="timeout">The max duration to wait for.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask IsTrue(Func<ValueTask<bool>> condition, string message, TimeSpan timeout, CancellationToken ct = default)
+	public static global::System.Threading.Tasks.ValueTask IsTrue(global::System.Func<global::System.Threading.Tasks.ValueTask<bool>> condition, string message, global::System.TimeSpan timeout, global::System.Threading.CancellationToken ct = default)
 		=> IsTrueCore(condition, message, timeout, ct);
 
 	/// <summary>
@@ -176,21 +167,21 @@ public static partial class AsyncAssert
 	/// <param name="message">The message to include in the exception when condition is not equal to expected. The message is shown in test results.</param>
 	/// <param name="timeoutMs">The max duration to wait for in milliseconds.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask IsTrue(Func<ValueTask<bool>> condition, string message, int timeoutMs, CancellationToken ct = default)
-		=> IsTrueCore(condition, message, TimeSpan.FromMilliseconds(timeoutMs), ct);
+	public static global::System.Threading.Tasks.ValueTask IsTrue(global::System.Func<global::System.Threading.Tasks.ValueTask<bool>> condition, string message, int timeoutMs, global::System.Threading.CancellationToken ct = default)
+		=> IsTrueCore(condition, message, global::System.TimeSpan.FromMilliseconds(timeoutMs), ct);
 
-	private static async ValueTask IsTrueCore(Func<bool> condition, string reason, TimeSpan timeout, CancellationToken ct)
+	private static async global::System.Threading.Tasks.ValueTask IsTrueCore(global::System.Func<bool> condition, string reason, global::System.TimeSpan timeout, global::System.Threading.CancellationToken ct)
 	{
 		await TestHelper.TryWaitFor(condition, timeout, ct);
 
-		Assert.IsTrue(condition(), reason);
+		global::Microsoft.VisualStudio.TestTools.UnitTesting.Assert.IsTrue(condition(), reason);
 	}
 
-	private static async ValueTask IsTrueCore(Func<ValueTask<bool>> condition, string reason, TimeSpan timeout, CancellationToken ct)
+	private static async global::System.Threading.Tasks.ValueTask IsTrueCore(global::System.Func<global::System.Threading.Tasks.ValueTask<bool>> condition, string reason, global::System.TimeSpan timeout, global::System.Threading.CancellationToken ct)
 	{
 		await TestHelper.TryWaitFor(async _ => await condition().ConfigureAwait(false), timeout, ct);
 
-		Assert.IsTrue(await condition().ConfigureAwait(false), reason);
+		global::Microsoft.VisualStudio.TestTools.UnitTesting.Assert.IsTrue(await condition().ConfigureAwait(false), reason);
 	}
 	#endregion
 
@@ -203,13 +194,13 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="conditionExpression">For debug purposes.</param>
-	public static ValueTask IsFalse(
-		Func<bool> condition,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("condition")] string conditionExpression = "")
-		=> IsFalseCore(condition, $"{conditionExpression} to be false but found true ({Path.GetFileName(file)}@{line})", TestHelper.DefaultTimeout, ct);
+	public static global::System.Threading.Tasks.ValueTask IsFalse(
+		global::System.Func<bool> condition,
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("condition")] string conditionExpression = "")
+		=> IsFalseCore(condition, $"{conditionExpression} to be false but found true ({(global::System.IO.Path.GetFileName(file))}@{line})", TestHelper.DefaultTimeout, ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified condition is false and throws an exception if the condition is true.
@@ -220,14 +211,14 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="conditionExpression">For debug purposes.</param>
-	public static ValueTask IsFalse(
-		Func<bool> condition,
-		TimeSpan timeout,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("condition")] string conditionExpression = "")
-		=> IsFalseCore(condition, $"{conditionExpression} to be false but found true ({Path.GetFileName(file)}@{line})", timeout, ct);
+	public static global::System.Threading.Tasks.ValueTask IsFalse(
+		global::System.Func<bool> condition,
+		global::System.TimeSpan timeout,
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("condition")] string conditionExpression = "")
+		=> IsFalseCore(condition, $"{conditionExpression} to be false but found true ({(global::System.IO.Path.GetFileName(file))}@{line})", timeout, ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified condition is false and throws an exception if the condition is true.
@@ -238,14 +229,14 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="conditionExpression">For debug purposes.</param>
-	public static ValueTask IsFalse(
-		Func<bool> condition,
+	public static global::System.Threading.Tasks.ValueTask IsFalse(
+		global::System.Func<bool> condition,
 		int timeoutMs,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("condition")] string conditionExpression = "")
-		=> IsFalseCore(condition, $"{conditionExpression} to be false but found true ({Path.GetFileName(file)}@{line})", TimeSpan.FromMilliseconds(timeoutMs), ct);
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("condition")] string conditionExpression = "")
+		=> IsFalseCore(condition, $"{conditionExpression} to be false but found true ({(global::System.IO.Path.GetFileName(file))}@{line})", global::System.TimeSpan.FromMilliseconds(timeoutMs), ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified condition is false and throws an exception if the condition is true.
@@ -253,7 +244,7 @@ public static partial class AsyncAssert
 	/// <param name="condition">The condition the test expects to be false.</param>
 	/// <param name="message">The message to include in the exception when condition is not equal to expected. The message is shown in test results.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask IsFalse(Func<bool> condition, string message, CancellationToken ct = default)
+	public static global::System.Threading.Tasks.ValueTask IsFalse(global::System.Func<bool> condition, string message, global::System.Threading.CancellationToken ct = default)
 		=> IsFalseCore(condition, message, TestHelper.DefaultTimeout, ct);
 
 	/// <summary>
@@ -263,7 +254,7 @@ public static partial class AsyncAssert
 	/// <param name="message">The message to include in the exception when condition is not equal to expected. The message is shown in test results.</param>
 	/// <param name="timeout">The max duration to wait for.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask IsFalse(Func<bool> condition, string message, TimeSpan timeout, CancellationToken ct = default)
+	public static global::System.Threading.Tasks.ValueTask IsFalse(global::System.Func<bool> condition, string message, global::System.TimeSpan timeout, global::System.Threading.CancellationToken ct = default)
 		=> IsFalseCore(condition, message, timeout, ct);
 
 	/// <summary>
@@ -273,8 +264,8 @@ public static partial class AsyncAssert
 	/// <param name="message">The message to include in the exception when condition is not equal to expected. The message is shown in test results.</param>
 	/// <param name="timeoutMs">The max duration to wait for in milliseconds.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask IsFalse(Func<bool> condition, string message, int timeoutMs, CancellationToken ct = default)
-		=> IsFalseCore(condition, message, TimeSpan.FromMilliseconds(timeoutMs), ct);
+	public static global::System.Threading.Tasks.ValueTask IsFalse(global::System.Func<bool> condition, string message, int timeoutMs, global::System.Threading.CancellationToken ct = default)
+		=> IsFalseCore(condition, message, global::System.TimeSpan.FromMilliseconds(timeoutMs), ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified condition is false and throws an exception if the condition is true.
@@ -284,13 +275,13 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="conditionExpression">For debug purposes.</param>
-	public static ValueTask IsFalse(
-		Func<ValueTask<bool>> condition,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("condition")] string conditionExpression = "")
-		=> IsFalseCore(condition, $"{conditionExpression} to be false but found true ({Path.GetFileName(file)}@{line})", TestHelper.DefaultTimeout, ct);
+	public static global::System.Threading.Tasks.ValueTask IsFalse(
+		global::System.Func<global::System.Threading.Tasks.ValueTask<bool>> condition,
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("condition")] string conditionExpression = "")
+		=> IsFalseCore(condition, $"{conditionExpression} to be false but found true ({(global::System.IO.Path.GetFileName(file))}@{line})", TestHelper.DefaultTimeout, ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified condition is false and throws an exception if the condition is true.
@@ -301,14 +292,14 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="conditionExpression">For debug purposes.</param>
-	public static ValueTask IsFalse(
-		Func<ValueTask<bool>> condition,
-		TimeSpan timeout,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("condition")] string conditionExpression = "")
-		=> IsFalseCore(condition, $"{conditionExpression} to be false but found true ({Path.GetFileName(file)}@{line})", timeout, ct);
+	public static global::System.Threading.Tasks.ValueTask IsFalse(
+		global::System.Func<global::System.Threading.Tasks.ValueTask<bool>> condition,
+		global::System.TimeSpan timeout,
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("condition")] string conditionExpression = "")
+		=> IsFalseCore(condition, $"{conditionExpression} to be false but found true ({(global::System.IO.Path.GetFileName(file))}@{line})", timeout, ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified condition is false and throws an exception if the condition is true.
@@ -319,14 +310,14 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="conditionExpression">For debug purposes.</param>
-	public static ValueTask IsFalse(
-		Func<ValueTask<bool>> condition,
+	public static global::System.Threading.Tasks.ValueTask IsFalse(
+		global::System.Func<global::System.Threading.Tasks.ValueTask<bool>> condition,
 		int timeoutMs,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("condition")] string conditionExpression = "")
-		=> IsFalseCore(condition, $"{conditionExpression} to be false but found true ({Path.GetFileName(file)}@{line})", TimeSpan.FromMilliseconds(timeoutMs), ct);
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("condition")] string conditionExpression = "")
+		=> IsFalseCore(condition, $"{conditionExpression} to be false but found true ({(global::System.IO.Path.GetFileName(file))}@{line})", global::System.TimeSpan.FromMilliseconds(timeoutMs), ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified condition is false and throws an exception if the condition is true.
@@ -334,7 +325,7 @@ public static partial class AsyncAssert
 	/// <param name="condition">The condition the test expects to be false.</param>
 	/// <param name="message">The message to include in the exception when condition is not equal to expected. The message is shown in test results.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask IsFalse(Func<ValueTask<bool>> condition, string message, CancellationToken ct = default)
+	public static global::System.Threading.Tasks.ValueTask IsFalse(global::System.Func<global::System.Threading.Tasks.ValueTask<bool>> condition, string message, global::System.Threading.CancellationToken ct = default)
 		=> IsFalseCore(condition, message, TestHelper.DefaultTimeout, ct);
 
 	/// <summary>
@@ -344,7 +335,7 @@ public static partial class AsyncAssert
 	/// <param name="message">The message to include in the exception when condition is not equal to expected. The message is shown in test results.</param>
 	/// <param name="timeout">The max duration to wait for.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask IsFalse(Func<ValueTask<bool>> condition, string message, TimeSpan timeout, CancellationToken ct = default)
+	public static global::System.Threading.Tasks.ValueTask IsFalse(global::System.Func<global::System.Threading.Tasks.ValueTask<bool>> condition, string message, global::System.TimeSpan timeout, global::System.Threading.CancellationToken ct = default)
 		=> IsFalseCore(condition, message, timeout, ct);
 
 	/// <summary>
@@ -354,21 +345,21 @@ public static partial class AsyncAssert
 	/// <param name="message">The message to include in the exception when condition is not equal to expected. The message is shown in test results.</param>
 	/// <param name="timeoutMs">The max duration to wait for in milliseconds.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask IsFalse(Func<ValueTask<bool>> condition, string message, int timeoutMs, CancellationToken ct = default)
-		=> IsFalseCore(condition, message, TimeSpan.FromMilliseconds(timeoutMs), ct);
+	public static global::System.Threading.Tasks.ValueTask IsFalse(global::System.Func<global::System.Threading.Tasks.ValueTask<bool>> condition, string message, int timeoutMs, global::System.Threading.CancellationToken ct = default)
+		=> IsFalseCore(condition, message, global::System.TimeSpan.FromMilliseconds(timeoutMs), ct);
 
-	private static async ValueTask IsFalseCore(Func<bool> condition, string reason, TimeSpan timeout, CancellationToken ct)
+	private static async global::System.Threading.Tasks.ValueTask IsFalseCore(global::System.Func<bool> condition, string reason, global::System.TimeSpan timeout, global::System.Threading.CancellationToken ct)
 	{
 		await TestHelper.TryWaitFor(() => !condition(), timeout, ct);
 
-		Assert.IsFalse(condition(), reason);
+		global::Microsoft.VisualStudio.TestTools.UnitTesting.Assert.IsFalse(condition(), reason);
 	}
 
-	private static async ValueTask IsFalseCore(Func<ValueTask<bool>> condition, string reason, TimeSpan timeout, CancellationToken ct)
+	private static async global::System.Threading.Tasks.ValueTask IsFalseCore(global::System.Func<global::System.Threading.Tasks.ValueTask<bool>> condition, string reason, global::System.TimeSpan timeout, global::System.Threading.CancellationToken ct)
 	{
 		await TestHelper.TryWaitFor(async _ => !await condition().ConfigureAwait(false), timeout, ct);
 
-		Assert.IsFalse(await condition().ConfigureAwait(false), reason);
+		global::Microsoft.VisualStudio.TestTools.UnitTesting.Assert.IsFalse(await condition().ConfigureAwait(false), reason);
 	}
 	#endregion
 
@@ -382,13 +373,13 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="valueExpression">For debug purposes.</param>
-	public static ValueTask IsNull<T>(
-		Func<T> value,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("value")] string valueExpression = "")
-		=> IsNullCore(value, a => $"{valueExpression} to be null but found {a} ({Path.GetFileName(file)}@{line})", TestHelper.DefaultTimeout, ct);
+	public static global::System.Threading.Tasks.ValueTask IsNull<T>(
+		global::System.Func<T> value,
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("value")] string valueExpression = "")
+		=> IsNullCore(value, a => $"{valueExpression} to be null but found {a} ({(global::System.IO.Path.GetFileName(file))}@{line})", TestHelper.DefaultTimeout, ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified object is null and throws an exception if it is not.
@@ -400,14 +391,14 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="valueExpression">For debug purposes.</param>
-	public static ValueTask IsNull<T>(
-		Func<T> value,
-		TimeSpan timeout,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("value")] string valueExpression = "")
-		=> IsNullCore(value, a => $"{valueExpression} to be null but found {a} ({Path.GetFileName(file)}@{line})", timeout, ct);
+	public static global::System.Threading.Tasks.ValueTask IsNull<T>(
+		global::System.Func<T> value,
+		global::System.TimeSpan timeout,
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("value")] string valueExpression = "")
+		=> IsNullCore(value, a => $"{valueExpression} to be null but found {a} ({(global::System.IO.Path.GetFileName(file))}@{line})", timeout, ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified object is null and throws an exception if it is not.
@@ -419,14 +410,14 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="valueExpression">For debug purposes.</param>
-	public static ValueTask IsNull<T>(
-		Func<T> value,
+	public static global::System.Threading.Tasks.ValueTask IsNull<T>(
+		global::System.Func<T> value,
 		int timeoutMs,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("value")] string valueExpression = "")
-		=> IsNullCore(value, a => $"{valueExpression} to be null but found {a} ({Path.GetFileName(file)}@{line})", TimeSpan.FromMilliseconds(timeoutMs), ct);
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("value")] string valueExpression = "")
+		=> IsNullCore(value, a => $"{valueExpression} to be null but found {a} ({(global::System.IO.Path.GetFileName(file))}@{line})", global::System.TimeSpan.FromMilliseconds(timeoutMs), ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified object is null and throws an exception if it is not.
@@ -435,7 +426,7 @@ public static partial class AsyncAssert
 	/// <param name="value">The object the test expects to be null.</param>
 	/// <param name="message">The message to include in the exception when value is not equal to expected. The message is shown in test results.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask IsNull<T>(Func<T> value, string message, CancellationToken ct = default)
+	public static global::System.Threading.Tasks.ValueTask IsNull<T>(global::System.Func<T> value, string message, global::System.Threading.CancellationToken ct = default)
 		=> IsNullCore(value, a => message, TestHelper.DefaultTimeout, ct);
 
 	/// <summary>
@@ -446,7 +437,7 @@ public static partial class AsyncAssert
 	/// <param name="message">The message to include in the exception when value is not equal to expected. The message is shown in test results.</param>
 	/// <param name="timeout">The max duration to wait for.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask IsNull<T>(Func<T> value, string message, TimeSpan timeout, CancellationToken ct = default)
+	public static global::System.Threading.Tasks.ValueTask IsNull<T>(global::System.Func<T> value, string message, global::System.TimeSpan timeout, global::System.Threading.CancellationToken ct = default)
 		=> IsNullCore(value, a => message, timeout, ct);
 
 	/// <summary>
@@ -457,8 +448,8 @@ public static partial class AsyncAssert
 	/// <param name="message">The message to include in the exception when value is not equal to expected. The message is shown in test results.</param>
 	/// <param name="timeoutMs">The max duration to wait for in milliseconds.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask IsNull<T>(Func<T> value, string message, int timeoutMs, CancellationToken ct = default)
-		=> IsNullCore(value, a => message, TimeSpan.FromMilliseconds(timeoutMs), ct);
+	public static global::System.Threading.Tasks.ValueTask IsNull<T>(global::System.Func<T> value, string message, int timeoutMs, global::System.Threading.CancellationToken ct = default)
+		=> IsNullCore(value, a => message, global::System.TimeSpan.FromMilliseconds(timeoutMs), ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified object is null and throws an exception if it is not.
@@ -469,13 +460,13 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="valueExpression">For debug purposes.</param>
-	public static ValueTask IsNull<T>(
-		Func<ValueTask<T>> value,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("value")] string valueExpression = "")
-		=> IsNullCore<T>(value, a => $"{valueExpression} to be null but found {a} ({Path.GetFileName(file)}@{line})", TestHelper.DefaultTimeout, ct);
+	public static global::System.Threading.Tasks.ValueTask IsNull<T>(
+		global::System.Func<global::System.Threading.Tasks.ValueTask<T>> value,
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("value")] string valueExpression = "")
+		=> IsNullCore<T>(value, a => $"{valueExpression} to be null but found {a} ({(global::System.IO.Path.GetFileName(file))}@{line})", TestHelper.DefaultTimeout, ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified object is null and throws an exception if it is not.
@@ -487,14 +478,14 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="valueExpression">For debug purposes.</param>
-	public static ValueTask IsNull<T>(
-		Func<ValueTask<T>> value,
-		TimeSpan timeout,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("value")] string valueExpression = "")
-		=> IsNullCore<T>(value, a => $"{valueExpression} to be null but found {a} ({Path.GetFileName(file)}@{line})", timeout, ct);
+	public static global::System.Threading.Tasks.ValueTask IsNull<T>(
+		global::System.Func<global::System.Threading.Tasks.ValueTask<T>> value,
+		global::System.TimeSpan timeout,
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("value")] string valueExpression = "")
+		=> IsNullCore<T>(value, a => $"{valueExpression} to be null but found {a} ({(global::System.IO.Path.GetFileName(file))}@{line})", timeout, ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified object is null and throws an exception if it is not.
@@ -506,14 +497,14 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="valueExpression">For debug purposes.</param>
-	public static ValueTask IsNull<T>(
-		Func<ValueTask<T>> value,
+	public static global::System.Threading.Tasks.ValueTask IsNull<T>(
+		global::System.Func<global::System.Threading.Tasks.ValueTask<T>> value,
 		int timeoutMs,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("value")] string valueExpression = "")
-		=> IsNullCore<T>(value, a => $"{valueExpression} to be null but found {a} ({Path.GetFileName(file)}@{line})", TimeSpan.FromMilliseconds(timeoutMs), ct);
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("value")] string valueExpression = "")
+		=> IsNullCore<T>(value, a => $"{valueExpression} to be null but found {a} ({(global::System.IO.Path.GetFileName(file))}@{line})", global::System.TimeSpan.FromMilliseconds(timeoutMs), ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified object is null and throws an exception if it is not.
@@ -522,7 +513,7 @@ public static partial class AsyncAssert
 	/// <param name="value">The object the test expects to be null.</param>
 	/// <param name="message">The message to include in the exception when value is not equal to expected. The message is shown in test results.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask IsNull<T>(Func<ValueTask<T>> value, string message, CancellationToken ct = default)
+	public static global::System.Threading.Tasks.ValueTask IsNull<T>(global::System.Func<global::System.Threading.Tasks.ValueTask<T>> value, string message, global::System.Threading.CancellationToken ct = default)
 		=> IsNullCore<T>(value, a => message, TestHelper.DefaultTimeout, ct);
 
 	/// <summary>
@@ -533,7 +524,7 @@ public static partial class AsyncAssert
 	/// <param name="message">The message to include in the exception when value is not equal to expected. The message is shown in test results.</param>
 	/// <param name="timeout">The max duration to wait for.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask IsNull<T>(Func<ValueTask<T>> value, string message, TimeSpan timeout, CancellationToken ct = default)
+	public static global::System.Threading.Tasks.ValueTask IsNull<T>(global::System.Func<global::System.Threading.Tasks.ValueTask<T>> value, string message, global::System.TimeSpan timeout, global::System.Threading.CancellationToken ct = default)
 		=> IsNullCore<T>(value, a => message, timeout, ct);
 
 	/// <summary>
@@ -544,23 +535,23 @@ public static partial class AsyncAssert
 	/// <param name="message">The message to include in the exception when value is not equal to expected. The message is shown in test results.</param>
 	/// <param name="timeoutMs">The max duration to wait for in milliseconds.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask IsNull<T>(Func<ValueTask<T>> value, string message, int timeoutMs, CancellationToken ct = default)
-		=> IsNullCore<T>(value, a => message, TimeSpan.FromMilliseconds(timeoutMs), ct);
+	public static global::System.Threading.Tasks.ValueTask IsNull<T>(global::System.Func<global::System.Threading.Tasks.ValueTask<T>> value, string message, int timeoutMs, global::System.Threading.CancellationToken ct = default)
+		=> IsNullCore<T>(value, a => message, global::System.TimeSpan.FromMilliseconds(timeoutMs), ct);
 
-	private static async ValueTask IsNullCore<T>(Func<T> value, Func<T, string> reason, TimeSpan timeout, CancellationToken ct)
+	private static async global::System.Threading.Tasks.ValueTask IsNullCore<T>(global::System.Func<T> value, global::System.Func<T, string> reason, global::System.TimeSpan timeout, global::System.Threading.CancellationToken ct)
 	{
 		await TestHelper.TryWaitFor(() => object.Equals(null, value()), timeout, ct);
 
 		var a = value();
-		Assert.IsNull(a, reason(a));
+		global::Microsoft.VisualStudio.TestTools.UnitTesting.Assert.IsNull(a, reason(a));
 	}
 
-	private static async ValueTask IsNullCore<T>(Func<ValueTask<T>> value, Func<T, string> reason, TimeSpan timeout, CancellationToken ct)
+	private static async global::System.Threading.Tasks.ValueTask IsNullCore<T>(global::System.Func<global::System.Threading.Tasks.ValueTask<T>> value, global::System.Func<T, string> reason, global::System.TimeSpan timeout, global::System.Threading.CancellationToken ct)
 	{
 		await TestHelper.TryWaitFor(async _ => object.Equals(null, await value().ConfigureAwait(false)), timeout, ct);
 
 		var a = await value().ConfigureAwait(false);
-		Assert.IsNotNull(a, reason(a));
+		global::Microsoft.VisualStudio.TestTools.UnitTesting.Assert.IsNotNull(a, reason(a));
 	}
 	#endregion
 
@@ -574,13 +565,13 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="valueExpression">For debug purposes.</param>
-	public static ValueTask IsNotNull<T>(
-		Func<T> value,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("value")] string valueExpression = "")
-		=> IsNotNullCore<T>(value, a => $"{valueExpression} to be null but found {a} ({Path.GetFileName(file)}@{line})", TestHelper.DefaultTimeout, ct);
+	public static global::System.Threading.Tasks.ValueTask IsNotNull<T>(
+		global::System.Func<T> value,
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("value")] string valueExpression = "")
+		=> IsNotNullCore<T>(value, a => $"{valueExpression} to be null but found {a} ({(global::System.IO.Path.GetFileName(file))}@{line})", TestHelper.DefaultTimeout, ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified object is non-null and throws an exception if it is null.
@@ -592,14 +583,14 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="valueExpression">For debug purposes.</param>
-	public static ValueTask IsNotNull<T>(
-		Func<T> value,
-		TimeSpan timeout,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("value")] string valueExpression = "")
-		=> IsNotNullCore<T>(value, a => $"{valueExpression} to be null but found {a} ({Path.GetFileName(file)}@{line})", timeout, ct);
+	public static global::System.Threading.Tasks.ValueTask IsNotNull<T>(
+		global::System.Func<T> value,
+		global::System.TimeSpan timeout,
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("value")] string valueExpression = "")
+		=> IsNotNullCore<T>(value, a => $"{valueExpression} to be null but found {a} ({(global::System.IO.Path.GetFileName(file))}@{line})", timeout, ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified object is non-null and throws an exception if it is null.
@@ -611,14 +602,14 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="valueExpression">For debug purposes.</param>
-	public static ValueTask IsNotNull<T>(
-		Func<T> value,
+	public static global::System.Threading.Tasks.ValueTask IsNotNull<T>(
+		global::System.Func<T> value,
 		int timeoutMs,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("value")] string valueExpression = "")
-		=> IsNotNullCore<T>(value, a => $"{valueExpression} to be null but found {a} ({Path.GetFileName(file)}@{line})", TimeSpan.FromMilliseconds(timeoutMs), ct);
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("value")] string valueExpression = "")
+		=> IsNotNullCore<T>(value, a => $"{valueExpression} to be null but found {a} ({(global::System.IO.Path.GetFileName(file))}@{line})", global::System.TimeSpan.FromMilliseconds(timeoutMs), ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified object is non-null and throws an exception if it is null.
@@ -627,7 +618,7 @@ public static partial class AsyncAssert
 	/// <param name="value">The object the test expects to be null.</param>
 	/// <param name="message">The message to include in the exception when value is not equal to expected. The message is shown in test results.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask IsNotNull<T>(Func<T> value, string message, CancellationToken ct = default)
+	public static global::System.Threading.Tasks.ValueTask IsNotNull<T>(global::System.Func<T> value, string message, global::System.Threading.CancellationToken ct = default)
 		=> IsNotNullCore<T>(value, a => message, TestHelper.DefaultTimeout, ct);
 
 	/// <summary>
@@ -638,7 +629,7 @@ public static partial class AsyncAssert
 	/// <param name="message">The message to include in the exception when value is not equal to expected. The message is shown in test results.</param>
 	/// <param name="timeout">The max duration to wait for.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask IsNotNull<T>(Func<T> value, string message, TimeSpan timeout, CancellationToken ct = default)
+	public static global::System.Threading.Tasks.ValueTask IsNotNull<T>(global::System.Func<T> value, string message, global::System.TimeSpan timeout, global::System.Threading.CancellationToken ct = default)
 		=> IsNotNullCore<T>(value, a => message, timeout, ct);
 
 	/// <summary>
@@ -649,8 +640,8 @@ public static partial class AsyncAssert
 	/// <param name="message">The message to include in the exception when value is not equal to expected. The message is shown in test results.</param>
 	/// <param name="timeoutMs">The max duration to wait for in milliseconds.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask IsNotNull<T>(Func<T> value, string message, int timeoutMs, CancellationToken ct = default)
-		=> IsNotNullCore<T>(value, a => message, TimeSpan.FromMilliseconds(timeoutMs), ct);
+	public static global::System.Threading.Tasks.ValueTask IsNotNull<T>(global::System.Func<T> value, string message, int timeoutMs, global::System.Threading.CancellationToken ct = default)
+		=> IsNotNullCore<T>(value, a => message, global::System.TimeSpan.FromMilliseconds(timeoutMs), ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified object is non-null and throws an exception if it is null.
@@ -661,13 +652,13 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="valueExpression">For debug purposes.</param>
-	public static ValueTask IsNotNull<T>(
-		Func<ValueTask<T>> value,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("value")] string valueExpression = "")
-		=> IsNotNullCore<T>(value, a => $"{valueExpression} to be null but found {a} ({Path.GetFileName(file)}@{line})", TestHelper.DefaultTimeout, ct);
+	public static global::System.Threading.Tasks.ValueTask IsNotNull<T>(
+		global::System.Func<global::System.Threading.Tasks.ValueTask<T>> value,
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("value")] string valueExpression = "")
+		=> IsNotNullCore<T>(value, a => $"{valueExpression} to be null but found {a} ({(global::System.IO.Path.GetFileName(file))}@{line})", TestHelper.DefaultTimeout, ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified object is non-null and throws an exception if it is null.
@@ -679,14 +670,14 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="valueExpression">For debug purposes.</param>
-	public static ValueTask IsNotNull<T>(
-		Func<ValueTask<T>> value,
-		TimeSpan timeout,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("value")] string valueExpression = "")
-		=> IsNotNullCore<T>(value, a => $"{valueExpression} to be null but found {a} ({Path.GetFileName(file)}@{line})", timeout, ct);
+	public static global::System.Threading.Tasks.ValueTask IsNotNull<T>(
+		global::System.Func<global::System.Threading.Tasks.ValueTask<T>> value,
+		global::System.TimeSpan timeout,
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("value")] string valueExpression = "")
+		=> IsNotNullCore<T>(value, a => $"{valueExpression} to be null but found {a} ({(global::System.IO.Path.GetFileName(file))}@{line})", timeout, ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified object is non-null and throws an exception if it is null.
@@ -698,14 +689,14 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="valueExpression">For debug purposes.</param>
-	public static ValueTask IsNotNull<T>(
-		Func<ValueTask<T>> value,
+	public static global::System.Threading.Tasks.ValueTask IsNotNull<T>(
+		global::System.Func<global::System.Threading.Tasks.ValueTask<T>> value,
 		int timeoutMs,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("value")] string valueExpression = "")
-		=> IsNotNullCore<T>(value, a => $"{valueExpression} to be null but found {a} ({Path.GetFileName(file)}@{line})", TimeSpan.FromMilliseconds(timeoutMs), ct);
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("value")] string valueExpression = "")
+		=> IsNotNullCore<T>(value, a => $"{valueExpression} to be null but found {a} ({(global::System.IO.Path.GetFileName(file))}@{line})", global::System.TimeSpan.FromMilliseconds(timeoutMs), ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified object is non-null and throws an exception if it is null.
@@ -714,7 +705,7 @@ public static partial class AsyncAssert
 	/// <param name="value">The object the test expects to be null.</param>
 	/// <param name="message">The message to include in the exception when value is not equal to expected. The message is shown in test results.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask IsNotNull<T>(Func<ValueTask<T>> value, string message, CancellationToken ct = default)
+	public static global::System.Threading.Tasks.ValueTask IsNotNull<T>(global::System.Func<global::System.Threading.Tasks.ValueTask<T>> value, string message, global::System.Threading.CancellationToken ct = default)
 		=> IsNotNullCore<T>(value, a => message, TestHelper.DefaultTimeout, ct);
 
 	/// <summary>
@@ -725,7 +716,7 @@ public static partial class AsyncAssert
 	/// <param name="message">The message to include in the exception when value is not equal to expected. The message is shown in test results.</param>
 	/// <param name="timeout">The max duration to wait for.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask IsNotNull<T>(Func<ValueTask<T>> value, string message, TimeSpan timeout, CancellationToken ct = default)
+	public static global::System.Threading.Tasks.ValueTask IsNotNull<T>(global::System.Func<global::System.Threading.Tasks.ValueTask<T>> value, string message, global::System.TimeSpan timeout, global::System.Threading.CancellationToken ct = default)
 		=> IsNotNullCore<T>(value, a => message, timeout, ct);
 
 	/// <summary>
@@ -736,23 +727,23 @@ public static partial class AsyncAssert
 	/// <param name="message">The message to include in the exception when value is not equal to expected. The message is shown in test results.</param>
 	/// <param name="timeoutMs">The max duration to wait for in milliseconds.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask IsNotNull<T>(Func<ValueTask<T>> value, string message, int timeoutMs, CancellationToken ct = default)
-		=> IsNotNullCore<T>(value, a => message, TimeSpan.FromMilliseconds(timeoutMs), ct);
+	public static global::System.Threading.Tasks.ValueTask IsNotNull<T>(global::System.Func<global::System.Threading.Tasks.ValueTask<T>> value, string message, int timeoutMs, global::System.Threading.CancellationToken ct = default)
+		=> IsNotNullCore<T>(value, a => message, global::System.TimeSpan.FromMilliseconds(timeoutMs), ct);
 
-	private static async ValueTask IsNotNullCore<T>(Func<T> value, Func<T, string> reason, TimeSpan timeout, CancellationToken ct)
+	private static async global::System.Threading.Tasks.ValueTask IsNotNullCore<T>(global::System.Func<T> value, global::System.Func<T, string> reason, global::System.TimeSpan timeout, global::System.Threading.CancellationToken ct)
 	{
 		await TestHelper.TryWaitFor(() => !object.Equals(null, value()), timeout, ct);
 
 		var a = value();
-		Assert.IsNotNull(a, reason(a));
+		global::Microsoft.VisualStudio.TestTools.UnitTesting.Assert.IsNotNull(a, reason(a));
 	}
 
-	private static async ValueTask IsNotNullCore<T>(Func<ValueTask<T>> value, Func<T, string> reason, TimeSpan timeout, CancellationToken ct)
+	private static async global::System.Threading.Tasks.ValueTask IsNotNullCore<T>(global::System.Func<global::System.Threading.Tasks.ValueTask<T>> value, global::System.Func<T, string> reason, global::System.TimeSpan timeout, global::System.Threading.CancellationToken ct)
 	{
 		await TestHelper.TryWaitFor(async _ => !object.Equals(null, await value().ConfigureAwait(false)), timeout, ct);
 
 		var a = await value().ConfigureAwait(false);
-		Assert.IsNotNull(a, reason(a));
+		global::Microsoft.VisualStudio.TestTools.UnitTesting.Assert.IsNotNull(a, reason(a));
 	}
 	#endregion
 
@@ -767,14 +758,14 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="actualExpression">For debug purposes.</param>
-	public static ValueTask AreEqual<T>(
+	public static global::System.Threading.Tasks.ValueTask AreEqual<T>(
 		T expected,
-		Func<T> actual,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("actual")] string actualExpression = "")
-		=> AreEqualCore(expected, actual, a => $"{actualExpression} to equals {expected} but found {a} ({Path.GetFileName(file)}@{line})", TestHelper.DefaultTimeout, ct);
+		global::System.Func<T> actual,
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string actualExpression = "")
+		=> AreEqualCore(expected, actual, a => $"{actualExpression} to equals {expected} but found {a} ({(global::System.IO.Path.GetFileName(file))}@{line})", TestHelper.DefaultTimeout, ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified values are equal and throws an exception if the two values are not equal. Different numeric types are treated as unequal even if the logical values are equal. 42L is not equal to 42.
@@ -787,15 +778,15 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="actualExpression">For debug purposes.</param>
-	public static ValueTask AreEqual<T>(
+	public static global::System.Threading.Tasks.ValueTask AreEqual<T>(
 		T expected,
-		Func<T> actual,
-		TimeSpan timeout,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("actual")] string actualExpression = "")
-		=> AreEqualCore(expected, actual, a => $"{actualExpression} to equals {expected} but found {a} ({Path.GetFileName(file)}@{line})", timeout, ct);
+		global::System.Func<T> actual,
+		global::System.TimeSpan timeout,
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string actualExpression = "")
+		=> AreEqualCore(expected, actual, a => $"{actualExpression} to equals {expected} but found {a} ({(global::System.IO.Path.GetFileName(file))}@{line})", timeout, ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified values are equal and throws an exception if the two values are not equal. Different numeric types are treated as unequal even if the logical values are equal. 42L is not equal to 42.
@@ -808,15 +799,15 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="actualExpression">For debug purposes.</param>
-	public static ValueTask AreEqual<T>(
+	public static global::System.Threading.Tasks.ValueTask AreEqual<T>(
 		T expected,
-		Func<T> actual,
+		global::System.Func<T> actual,
 		int timeoutMs,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("actual")] string actualExpression = "")
-		=> AreEqualCore(expected, actual, a => $"{actualExpression} to equals {expected} but found {a} ({Path.GetFileName(file)}@{line})", TimeSpan.FromMilliseconds(timeoutMs), ct);
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string actualExpression = "")
+		=> AreEqualCore(expected, actual, a => $"{actualExpression} to equals {expected} but found {a} ({(global::System.IO.Path.GetFileName(file))}@{line})", global::System.TimeSpan.FromMilliseconds(timeoutMs), ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified values are equal and throws an exception if the two values are not equal. Different numeric types are treated as unequal even if the logical values are equal. 42L is not equal to 42.
@@ -826,7 +817,7 @@ public static partial class AsyncAssert
 	/// <param name="actual">The second value to compare. This is the value produced by the code under test.</param>
 	/// <param name="message">The message to include in the exception when actual is not equal to expected. The message is shown in test results.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask AreEqual<T>(T expected, Func<T> actual, string message, CancellationToken ct = default)
+	public static global::System.Threading.Tasks.ValueTask AreEqual<T>(T expected, global::System.Func<T> actual, string message, global::System.Threading.CancellationToken ct = default)
 		=> AreEqualCore(expected, actual, a => message, TestHelper.DefaultTimeout, ct);
 
 	/// <summary>
@@ -838,7 +829,7 @@ public static partial class AsyncAssert
 	/// <param name="message">The message to include in the exception when actual is not equal to expected. The message is shown in test results.</param>
 	/// <param name="timeout">The max duration to wait for.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask AreEqual<T>(T expected, Func<T> actual, string message, TimeSpan timeout, CancellationToken ct = default)
+	public static global::System.Threading.Tasks.ValueTask AreEqual<T>(T expected, global::System.Func<T> actual, string message, global::System.TimeSpan timeout, global::System.Threading.CancellationToken ct = default)
 		=> AreEqualCore(expected, actual, a => message, timeout, ct);
 
 	/// <summary>
@@ -850,8 +841,8 @@ public static partial class AsyncAssert
 	/// <param name="message">The message to include in the exception when actual is not equal to expected. The message is shown in test results.</param>
 	/// <param name="timeoutMs">The max duration to wait for in milliseconds.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask AreEqual<T>(T expected, Func<T> actual, string message, int timeoutMs, CancellationToken ct = default)
-		=> AreEqualCore(expected, actual, a => message, TimeSpan.FromMilliseconds(timeoutMs), ct);
+	public static global::System.Threading.Tasks.ValueTask AreEqual<T>(T expected, global::System.Func<T> actual, string message, int timeoutMs, global::System.Threading.CancellationToken ct = default)
+		=> AreEqualCore(expected, actual, a => message, global::System.TimeSpan.FromMilliseconds(timeoutMs), ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified values are equal and throws an exception if the two values are not equal. Different numeric types are treated as unequal even if the logical values are equal. 42L is not equal to 42.
@@ -863,14 +854,14 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="actualExpression">For debug purposes.</param>
-	public static ValueTask AreEqual<T>(
+	public static global::System.Threading.Tasks.ValueTask AreEqual<T>(
 		T expected,
-		Func<ValueTask<T>> actual,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("actual")] string actualExpression = "")
-		=> AreEqualCore(expected, actual, a => $"{actualExpression} to equals {expected} but found {a} ({Path.GetFileName(file)}@{line})", TestHelper.DefaultTimeout, ct);
+		global::System.Func<global::System.Threading.Tasks.ValueTask<T>> actual,
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string actualExpression = "")
+		=> AreEqualCore(expected, actual, a => $"{actualExpression} to equals {expected} but found {a} ({(global::System.IO.Path.GetFileName(file))}@{line})", TestHelper.DefaultTimeout, ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified values are equal and throws an exception if the two values are not equal. Different numeric types are treated as unequal even if the logical values are equal. 42L is not equal to 42.
@@ -883,15 +874,15 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="actualExpression">For debug purposes.</param>
-	public static ValueTask AreEqual<T>(
+	public static global::System.Threading.Tasks.ValueTask AreEqual<T>(
 		T expected,
-		Func<ValueTask<T>> actual,
-		TimeSpan timeout,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("actual")] string actualExpression = "")
-		=> AreEqualCore(expected, actual, a => $"{actualExpression} to equals {expected} but found {a} ({Path.GetFileName(file)}@{line})", timeout, ct);
+		global::System.Func<global::System.Threading.Tasks.ValueTask<T>> actual,
+		global::System.TimeSpan timeout,
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string actualExpression = "")
+		=> AreEqualCore(expected, actual, a => $"{actualExpression} to equals {expected} but found {a} ({(global::System.IO.Path.GetFileName(file))}@{line})", timeout, ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified values are equal and throws an exception if the two values are not equal. Different numeric types are treated as unequal even if the logical values are equal. 42L is not equal to 42.
@@ -904,15 +895,15 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="actualExpression">For debug purposes.</param>
-	public static ValueTask AreEqual<T>(
+	public static global::System.Threading.Tasks.ValueTask AreEqual<T>(
 		T expected,
-		Func<ValueTask<T>> actual,
+		global::System.Func<global::System.Threading.Tasks.ValueTask<T>> actual,
 		int timeoutMs,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("actual")] string actualExpression = "")
-		=> AreEqualCore(expected, actual, a => $"{actualExpression} to equals {expected} but found {a} ({Path.GetFileName(file)}@{line})", TimeSpan.FromMilliseconds(timeoutMs), ct);
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string actualExpression = "")
+		=> AreEqualCore(expected, actual, a => $"{actualExpression} to equals {expected} but found {a} ({(global::System.IO.Path.GetFileName(file))}@{line})", global::System.TimeSpan.FromMilliseconds(timeoutMs), ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified values are equal and throws an exception if the two values are not equal. Different numeric types are treated as unequal even if the logical values are equal. 42L is not equal to 42.
@@ -922,7 +913,7 @@ public static partial class AsyncAssert
 	/// <param name="actual">The second value to compare. This is the value produced by the code under test.</param>
 	/// <param name="message">The message to include in the exception when actual is not equal to expected. The message is shown in test results.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask AreEqual<T>(T expected, Func<ValueTask<T>> actual, string message, CancellationToken ct = default)
+	public static global::System.Threading.Tasks.ValueTask AreEqual<T>(T expected, global::System.Func<global::System.Threading.Tasks.ValueTask<T>> actual, string message, global::System.Threading.CancellationToken ct = default)
 		=> AreEqualCore(expected, actual, a => message, TestHelper.DefaultTimeout, ct);
 
 	/// <summary>
@@ -934,7 +925,7 @@ public static partial class AsyncAssert
 	/// <param name="message">The message to include in the exception when actual is not equal to expected. The message is shown in test results.</param>
 	/// <param name="timeout">The max duration to wait for.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask AreEqual<T>(T expected, Func<ValueTask<T>> actual, string message, TimeSpan timeout, CancellationToken ct = default)
+	public static global::System.Threading.Tasks.ValueTask AreEqual<T>(T expected, global::System.Func<global::System.Threading.Tasks.ValueTask<T>> actual, string message, global::System.TimeSpan timeout, global::System.Threading.CancellationToken ct = default)
 		=> AreEqualCore(expected, actual, a => message, timeout, ct);
 
 	/// <summary>
@@ -946,23 +937,23 @@ public static partial class AsyncAssert
 	/// <param name="message">The message to include in the exception when actual is not equal to expected. The message is shown in test results.</param>
 	/// <param name="timeoutMs">The max duration to wait for in milliseconds.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask AreEqual<T>(T expected, Func<ValueTask<T>> actual, string message, int timeoutMs, CancellationToken ct = default)
-		=> AreEqualCore(expected, actual, a => message, TimeSpan.FromMilliseconds(timeoutMs), ct);
+	public static global::System.Threading.Tasks.ValueTask AreEqual<T>(T expected, global::System.Func<global::System.Threading.Tasks.ValueTask<T>> actual, string message, int timeoutMs, global::System.Threading.CancellationToken ct = default)
+		=> AreEqualCore(expected, actual, a => message, global::System.TimeSpan.FromMilliseconds(timeoutMs), ct);
 
-	private static async ValueTask AreEqualCore<T>(T expected, Func<T> actual, Func<T, string> reason, TimeSpan timeout, CancellationToken ct)
+	private static async global::System.Threading.Tasks.ValueTask AreEqualCore<T>(T expected, global::System.Func<T> actual, global::System.Func<T, string> reason, global::System.TimeSpan timeout, global::System.Threading.CancellationToken ct)
 	{
 		await TestHelper.TryWaitFor(() => object.Equals(expected, actual()), timeout, ct);
 
 		var a = actual();
-		Assert.AreEqual(expected, a, reason(a));
+		global::Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreEqual(expected, a, reason(a));
 	}
 
-	private static async ValueTask AreEqualCore<T>(T expected, Func<ValueTask<T>> actual, Func<T, string> reason, TimeSpan timeout, CancellationToken ct)
+	private static async global::System.Threading.Tasks.ValueTask AreEqualCore<T>(T expected, global::System.Func<global::System.Threading.Tasks.ValueTask<T>> actual, global::System.Func<T, string> reason, global::System.TimeSpan timeout, global::System.Threading.CancellationToken ct)
 	{
 		await TestHelper.TryWaitFor(async _ => object.Equals(expected, await actual().ConfigureAwait(false)), timeout, ct);
 
 		var a = await actual().ConfigureAwait(false);
-		Assert.AreEqual(expected, a, reason(a));
+		global::Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreEqual(expected, a, reason(a));
 	}
 	#endregion
 
@@ -977,14 +968,14 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="actualExpression">For debug purposes.</param>
-	public static ValueTask AreNotEqual<T>(
+	public static global::System.Threading.Tasks.ValueTask AreNotEqual<T>(
 		T expected,
-		Func<T> actual,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("actual")] string actualExpression = "")
-		=> AreNotEqualCore(expected, actual, a => $"{actualExpression} to equals {expected} but found {a} ({Path.GetFileName(file)}@{line})", TestHelper.DefaultTimeout, ct);
+		global::System.Func<T> actual,
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string actualExpression = "")
+		=> AreNotEqualCore(expected, actual, a => $"{actualExpression} to equals {expected} but found {a} ({(global::System.IO.Path.GetFileName(file))}@{line})", TestHelper.DefaultTimeout, ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified values are unequal and throws an exception if the two values are equal. Different numeric types are treated as unequal even if the logical values are equal. 42L is not equal to 42.
@@ -997,15 +988,15 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="actualExpression">For debug purposes.</param>
-	public static ValueTask AreNotEqual<T>(
+	public static global::System.Threading.Tasks.ValueTask AreNotEqual<T>(
 		T expected,
-		Func<T> actual,
-		TimeSpan timeout,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("actual")] string actualExpression = "")
-		=> AreNotEqualCore(expected, actual, a => $"{actualExpression} to equals {expected} but found {a} ({Path.GetFileName(file)}@{line})", timeout, ct);
+		global::System.Func<T> actual,
+		global::System.TimeSpan timeout,
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string actualExpression = "")
+		=> AreNotEqualCore(expected, actual, a => $"{actualExpression} to equals {expected} but found {a} ({(global::System.IO.Path.GetFileName(file))}@{line})", timeout, ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified values are unequal and throws an exception if the two values are equal. Different numeric types are treated as unequal even if the logical values are equal. 42L is not equal to 42.
@@ -1018,15 +1009,15 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="actualExpression">For debug purposes.</param>
-	public static ValueTask AreNotEqual<T>(
+	public static global::System.Threading.Tasks.ValueTask AreNotEqual<T>(
 		T expected,
-		Func<T> actual,
+		global::System.Func<T> actual,
 		int timeoutMs,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("actual")] string actualExpression = "")
-		=> AreNotEqualCore(expected, actual, a => $"{actualExpression} to equals {expected} but found {a} ({Path.GetFileName(file)}@{line})", TimeSpan.FromMilliseconds(timeoutMs), ct);
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string actualExpression = "")
+		=> AreNotEqualCore(expected, actual, a => $"{actualExpression} to equals {expected} but found {a} ({(global::System.IO.Path.GetFileName(file))}@{line})", global::System.TimeSpan.FromMilliseconds(timeoutMs), ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified values are unequal and throws an exception if the two values are equal. Different numeric types are treated as unequal even if the logical values are equal. 42L is not equal to 42.
@@ -1036,7 +1027,7 @@ public static partial class AsyncAssert
 	/// <param name="actual">The second value to compare. This is the value produced by the code under test.</param>
 	/// <param name="message">The message to include in the exception when actual is not equal to expected. The message is shown in test results.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask AreNotEqual<T>(T expected, Func<T> actual, string message, CancellationToken ct = default)
+	public static global::System.Threading.Tasks.ValueTask AreNotEqual<T>(T expected, global::System.Func<T> actual, string message, global::System.Threading.CancellationToken ct = default)
 		=> AreNotEqualCore(expected, actual, a => message, TestHelper.DefaultTimeout, ct);
 
 	/// <summary>
@@ -1048,7 +1039,7 @@ public static partial class AsyncAssert
 	/// <param name="message">The message to include in the exception when actual is not equal to expected. The message is shown in test results.</param>
 	/// <param name="timeout">The max duration to wait for.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask AreNotEqual<T>(T expected, Func<T> actual, string message, TimeSpan timeout, CancellationToken ct = default)
+	public static global::System.Threading.Tasks.ValueTask AreNotEqual<T>(T expected, global::System.Func<T> actual, string message, global::System.TimeSpan timeout, global::System.Threading.CancellationToken ct = default)
 		=> AreNotEqualCore(expected, actual, a => message, timeout, ct);
 
 	/// <summary>
@@ -1060,8 +1051,8 @@ public static partial class AsyncAssert
 	/// <param name="message">The message to include in the exception when actual is not equal to expected. The message is shown in test results.</param>
 	/// <param name="timeoutMs">The max duration to wait for in milliseconds.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask AreNotEqual<T>(T expected, Func<T> actual, string message, int timeoutMs, CancellationToken ct = default)
-		=> AreNotEqualCore(expected, actual, a => message, TimeSpan.FromMilliseconds(timeoutMs), ct);
+	public static global::System.Threading.Tasks.ValueTask AreNotEqual<T>(T expected, global::System.Func<T> actual, string message, int timeoutMs, global::System.Threading.CancellationToken ct = default)
+		=> AreNotEqualCore(expected, actual, a => message, global::System.TimeSpan.FromMilliseconds(timeoutMs), ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified values are unequal and throws an exception if the two values are equal. Different numeric types are treated as unequal even if the logical values are equal. 42L is not equal to 42.
@@ -1073,14 +1064,14 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="actualExpression">For debug purposes.</param>
-	public static ValueTask AreNotEqual<T>(
+	public static global::System.Threading.Tasks.ValueTask AreNotEqual<T>(
 		T expected,
-		Func<ValueTask<T>> actual,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("actual")] string actualExpression = "")
-		=> AreNotEqualCore(expected, actual, a => $"{actualExpression} to equals {expected} but found {a} ({Path.GetFileName(file)}@{line})", TestHelper.DefaultTimeout, ct);
+		global::System.Func<global::System.Threading.Tasks.ValueTask<T>> actual,
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string actualExpression = "")
+		=> AreNotEqualCore(expected, actual, a => $"{actualExpression} to equals {expected} but found {a} ({(global::System.IO.Path.GetFileName(file))}@{line})", TestHelper.DefaultTimeout, ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified values are unequal and throws an exception if the two values are equal. Different numeric types are treated as unequal even if the logical values are equal. 42L is not equal to 42.
@@ -1093,15 +1084,15 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="actualExpression">For debug purposes.</param>
-	public static ValueTask AreNotEqual<T>(
+	public static global::System.Threading.Tasks.ValueTask AreNotEqual<T>(
 		T expected,
-		Func<ValueTask<T>> actual,
-		TimeSpan timeout,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("actual")] string actualExpression = "")
-		=> AreNotEqualCore(expected, actual, a => $"{actualExpression} to equals {expected} but found {a} ({Path.GetFileName(file)}@{line})", timeout, ct);
+		global::System.Func<global::System.Threading.Tasks.ValueTask<T>> actual,
+		global::System.TimeSpan timeout,
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string actualExpression = "")
+		=> AreNotEqualCore(expected, actual, a => $"{actualExpression} to equals {expected} but found {a} ({(global::System.IO.Path.GetFileName(file))}@{line})", timeout, ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified values are unequal and throws an exception if the two values are equal. Different numeric types are treated as unequal even if the logical values are equal. 42L is not equal to 42.
@@ -1114,15 +1105,15 @@ public static partial class AsyncAssert
 	/// <param name="line">For debug purposes.</param>
 	/// <param name="file">For debug purposes.</param>
 	/// <param name="actualExpression">For debug purposes.</param>
-	public static ValueTask AreNotEqual<T>(
+	public static global::System.Threading.Tasks.ValueTask AreNotEqual<T>(
 		T expected,
-		Func<ValueTask<T>> actual,
+		global::System.Func<global::System.Threading.Tasks.ValueTask<T>> actual,
 		int timeoutMs,
-		CancellationToken ct = default,
-		[CallerLineNumber] int line = -1,
-		[CallerFilePath] string file = "",
-		[CallerArgumentExpression("actual")] string actualExpression = "")
-		=> AreNotEqualCore(expected, actual, a => $"{actualExpression} to equals {expected} but found {a} ({Path.GetFileName(file)}@{line})", TimeSpan.FromMilliseconds(timeoutMs), ct);
+		global::System.Threading.CancellationToken ct = default,
+		[global::System.Runtime.CompilerServices.CallerLineNumber] int line = -1,
+		[global::System.Runtime.CompilerServices.CallerFilePath] string file = "",
+		[global::System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string actualExpression = "")
+		=> AreNotEqualCore(expected, actual, a => $"{actualExpression} to equals {expected} but found {a} ({(global::System.IO.Path.GetFileName(file))}@{line})", global::System.TimeSpan.FromMilliseconds(timeoutMs), ct);
 
 	/// <summary>
 	/// Asynchronously tests whether the specified values are unequal and throws an exception if the two values are equal. Different numeric types are treated as unequal even if the logical values are equal. 42L is not equal to 42.
@@ -1132,7 +1123,7 @@ public static partial class AsyncAssert
 	/// <param name="actual">The second value to compare. This is the value produced by the code under test.</param>
 	/// <param name="message">The message to include in the exception when actual is not equal to expected. The message is shown in test results.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask AreNotEqual<T>(T expected, Func<ValueTask<T>> actual, string message, CancellationToken ct = default)
+	public static global::System.Threading.Tasks.ValueTask AreNotEqual<T>(T expected, global::System.Func<global::System.Threading.Tasks.ValueTask<T>> actual, string message, global::System.Threading.CancellationToken ct = default)
 		=> AreNotEqualCore(expected, actual, a => message, TestHelper.DefaultTimeout, ct);
 
 	/// <summary>
@@ -1144,7 +1135,7 @@ public static partial class AsyncAssert
 	/// <param name="message">The message to include in the exception when actual is not equal to expected. The message is shown in test results.</param>
 	/// <param name="timeout">The max duration to wait for.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask AreNotEqual<T>(T expected, Func<ValueTask<T>> actual, string message, TimeSpan timeout, CancellationToken ct = default)
+	public static global::System.Threading.Tasks.ValueTask AreNotEqual<T>(T expected, global::System.Func<global::System.Threading.Tasks.ValueTask<T>> actual, string message, global::System.TimeSpan timeout, global::System.Threading.CancellationToken ct = default)
 		=> AreNotEqualCore(expected, actual, a => message, timeout, ct);
 
 	/// <summary>
@@ -1156,23 +1147,23 @@ public static partial class AsyncAssert
 	/// <param name="message">The message to include in the exception when actual is not equal to expected. The message is shown in test results.</param>
 	/// <param name="timeoutMs">The max duration to wait for in milliseconds.</param>
 	/// <param name="ct">Cancellation token to cancel teh asynchronous operation</param>
-	public static ValueTask AreNotEqual<T>(T expected, Func<ValueTask<T>> actual, string message, int timeoutMs, CancellationToken ct = default)
-		=> AreNotEqualCore(expected, actual, a => message, TimeSpan.FromMilliseconds(timeoutMs), ct);
+	public static global::System.Threading.Tasks.ValueTask AreNotEqual<T>(T expected, global::System.Func<global::System.Threading.Tasks.ValueTask<T>> actual, string message, int timeoutMs, global::System.Threading.CancellationToken ct = default)
+		=> AreNotEqualCore(expected, actual, a => message, global::System.TimeSpan.FromMilliseconds(timeoutMs), ct);
 
-	private static async ValueTask AreNotEqualCore<T>(T expected, Func<T> actual, Func<T, string> reason, TimeSpan timeout, CancellationToken ct)
+	private static async global::System.Threading.Tasks.ValueTask AreNotEqualCore<T>(T expected, global::System.Func<T> actual, global::System.Func<T, string> reason, global::System.TimeSpan timeout, global::System.Threading.CancellationToken ct)
 	{
 		await TestHelper.TryWaitFor(() => !object.Equals(expected, actual()), timeout, ct);
 
 		var a = actual();
-		Assert.AreNotEqual(expected, a, reason(a));
+		global::Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreNotEqual(expected, a, reason(a));
 	}
 
-	private static async ValueTask AreNotEqualCore<T>(T expected, Func<ValueTask<T>> actual, Func<T, string> reason, TimeSpan timeout, CancellationToken ct)
+	private static async global::System.Threading.Tasks.ValueTask AreNotEqualCore<T>(T expected, global::System.Func<global::System.Threading.Tasks.ValueTask<T>> actual, global::System.Func<T, string> reason, global::System.TimeSpan timeout, global::System.Threading.CancellationToken ct)
 	{
 		await TestHelper.TryWaitFor(async _ => !object.Equals(expected, await actual().ConfigureAwait(false)), timeout, ct);
 
 		var a = await actual().ConfigureAwait(false);
-		Assert.AreNotEqual(expected, a, reason(a));
+		global::Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreNotEqual(expected, a, reason(a));
 	}
 	#endregion
 }

--- a/src/Uno.UI.RuntimeTests.Engine.Library/Library/Helpers/HotReloadHelper.Local.cs
+++ b/src/Uno.UI.RuntimeTests.Engine.Library/Library/Helpers/HotReloadHelper.Local.cs
@@ -4,14 +4,6 @@
 #pragma warning disable
 #endif
 
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.IO;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace Uno.UI.RuntimeTests;
 
 partial class HotReloadHelper
@@ -19,27 +11,27 @@ partial class HotReloadHelper
 	static partial void TryUseLocalFileUpdater()
 		=> Use(new LocalFileUpdater());
 
-	[EditorBrowsable(EditorBrowsableState.Advanced)]
+	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Advanced)]
 	public static void UseLocalFileUpdater()
 		=> Use(new LocalFileUpdater());
 
 	private class LocalFileUpdater : IFileUpdater
 	{
 		/// <inheritdoc />
-		public async ValueTask EnsureReady(CancellationToken ct) { }
+		public async global::System.Threading.Tasks.ValueTask EnsureReady(global::System.Threading.CancellationToken ct) { }
 
 		/// <inheritdoc />
-		public async ValueTask<ReConnect?> Apply(FileEdit edition, CancellationToken ct)
+		public async global::System.Threading.Tasks.ValueTask<ReConnect?> Apply(FileEdit edition, global::System.Threading.CancellationToken ct)
 		{
-			if (!File.Exists(edition.FilePath))
+			if (!global::System.IO.File.Exists(edition.FilePath))
 			{
-				throw new InvalidOperationException($"Source file {edition.FilePath} does not exist!");
+				throw new global::System.InvalidOperationException($"Source file {edition.FilePath} does not exist!");
 			}
 
-			var originalContent = await File.ReadAllTextAsync(edition.FilePath, ct);
+			var originalContent = await global::System.IO.File.ReadAllTextAsync(edition.FilePath, ct);
 			var updatedContent = originalContent.Replace(edition.OldText, edition.NewText);
 
-			await File.WriteAllTextAsync(edition.FilePath, updatedContent, ct);
+			await global::System.IO.File.WriteAllTextAsync(edition.FilePath, updatedContent, ct);
 
 			return null;
 		}

--- a/src/Uno.UI.RuntimeTests.Engine.Library/Library/Helpers/HotReloadHelper.MetadataUpdateHandler.cs
+++ b/src/Uno.UI.RuntimeTests.Engine.Library/Library/Helpers/HotReloadHelper.MetadataUpdateHandler.cs
@@ -4,12 +4,7 @@
 #pragma warning disable
 #endif
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-using Uno.UI.RuntimeTests;
-
-[assembly:System.Reflection.Metadata.MetadataUpdateHandlerAttribute(typeof(HotReloadHelper.MetadataUpdateHandler))]
+[assembly:System.Reflection.Metadata.MetadataUpdateHandlerAttribute(typeof(global::Uno.UI.RuntimeTests.HotReloadHelper.MetadataUpdateHandler))]
 
 namespace Uno.UI.RuntimeTests;
 
@@ -17,11 +12,11 @@ partial class HotReloadHelper
 {
 	internal static class MetadataUpdateHandler
 	{
-		public static event EventHandler? MetadataUpdated;
+		public static event global::System.EventHandler? MetadataUpdated;
 
-		internal static void UpdateApplication(Type[]? types)
+		internal static void UpdateApplication(global::System.Type[]? types)
 		{
-			MetadataUpdated?.Invoke(null, EventArgs.Empty);
+			MetadataUpdated?.Invoke(null, global::System.EventArgs.Empty);
 		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests.Engine.Library/Library/Helpers/HotReloadHelper.NotSupported.cs
+++ b/src/Uno.UI.RuntimeTests.Engine.Library/Library/Helpers/HotReloadHelper.NotSupported.cs
@@ -4,11 +4,6 @@
 #pragma warning disable
 #endif
 
-using System;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace Uno.UI.RuntimeTests;
 
 public static partial class HotReloadHelper
@@ -16,12 +11,12 @@ public static partial class HotReloadHelper
 	private class NotSupported : IFileUpdater
 	{
 		/// <inheritdoc />
-		public ValueTask EnsureReady(CancellationToken ct)
-			=> throw new NotSupportedException("Source code file edition is not supported on this platform.");
+		public global::System.Threading.Tasks.ValueTask EnsureReady(global::System.Threading.CancellationToken ct)
+			=> throw new global::System.NotSupportedException("Source code file edition is not supported on this platform.");
 
 		/// <inheritdoc />
-		public ValueTask<ReConnect?> Apply(FileEdit edition, CancellationToken ct)
-			=> throw new NotSupportedException("Source code file edition is not supported on this platform.");
+		public global::System.Threading.Tasks.ValueTask<ReConnect?> Apply(FileEdit edition, global::System.Threading.CancellationToken ct)
+			=> throw new global::System.NotSupportedException("Source code file edition is not supported on this platform.");
 	}
 }
 #endif


### PR DESCRIPTION
## Feature
Make runtime tests engine more global using friendly

## What is the current behavior?
Build fails when use global using

## What is the new behavior?
Reduce risk of failure

## PR Checklist

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
