### PR TITLE
chore: Allow a runtime test engine to start a nested instance

### DIFF
--- a/src/Uno.UI.RuntimeTests.Engine.Library/Engine/ExternalRunner/_Private/SecondaryApp.cs
+++ b/src/Uno.UI.RuntimeTests.Engine.Library/Engine/ExternalRunner/_Private/SecondaryApp.cs
@@ -90,14 +90,14 @@ internal static partial class SecondaryApp
 		childStartInfo.EnvironmentVariables["DOTNET_MODIFIABLE_ASSEMBLIES"] = "debug";
 
 		// Requests to the uno app to attempt to connect to the given dev-server instance
-		childStartInfo.EnvironmentVariables.Add("UNO_DEV_SERVER_HOST", devServerHost);
-		childStartInfo.EnvironmentVariables.Add("UNO_DEV_SERVER_PORT", devServerPort.ToString());
+		childStartInfo.EnvironmentVariables["UNO_DEV_SERVER_HOST"] = devServerHost;
+		childStartInfo.EnvironmentVariables["UNO_DEV_SERVER_PORT"] = devServerPort.ToString();
 
 		// Request to the runtime tests engine to auto-start at startup
-		childStartInfo.EnvironmentVariables.Add("UNO_RUNTIME_TESTS_RUN_TESTS", configJson);
-		childStartInfo.EnvironmentVariables.Add("UNO_RUNTIME_TESTS_OUTPUT_PATH", testOutput);
-		childStartInfo.EnvironmentVariables.Add("UNO_RUNTIME_TESTS_OUTPUT_KIND", "UnoRuntimeTests"); // "NUnit"
-		childStartInfo.EnvironmentVariables.Add("UNO_RUNTIME_TESTS_IS_SECONDARY_APP", "true"); // "NUnit"
+		childStartInfo.EnvironmentVariables["UNO_RUNTIME_TESTS_RUN_TESTS"] = configJson;
+		childStartInfo.EnvironmentVariables["UNO_RUNTIME_TESTS_OUTPUT_PATH"] = testOutput;
+		childStartInfo.EnvironmentVariables["UNO_RUNTIME_TESTS_OUTPUT_KIND"] = "UnoRuntimeTests"; // "NUnit"
+		childStartInfo.EnvironmentVariables["UNO_RUNTIME_TESTS_IS_SECONDARY_APP"] = "true"; // "NUnit"
 
 		var childProcess = new global::System.Diagnostics.Process { StartInfo = childStartInfo };
 


### PR DESCRIPTION
## Feature
Allow a runtime-test runner to start a nested instance
This allow a runtime-test runner running on a CI to start a new instance for hot-reload tests

## What is the current behavior?
The CI fails to start a second app as some environnement variables are already set

## What is the new behavior?
We only update environnement variables, never try to add it!

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
