### PR TITLE
Avoid secondary app init if test class has been ignored

### DIFF
--- a/src/TestApp/shared/FilterTests.cs
+++ b/src/TestApp/shared/FilterTests.cs
@@ -69,7 +69,7 @@ public class FilterTests
 	[DataRow("!abcd | def", "abc.def.g.h.i", true)]
 	public void When_ParseAndMatch(string filter, string method, bool expectedResult)
 	{
-		UnitTestFilter sut =  filter;
+		UnitTestFilter sut = filter;
 		var result = sut.IsMatch(method);
 
 		Assert.AreEqual(expectedResult, result);

--- a/src/Uno.UI.RuntimeTests.Engine.Library/Engine/ExternalRunner/_Private/DevServer.cs
+++ b/src/Uno.UI.RuntimeTests.Engine.Library/Engine/ExternalRunner/_Private/DevServer.cs
@@ -151,8 +151,8 @@ public sealed partial class DevServer : global::System.IAsyncDisposable
 					dir,
 					log);
 
-				return GetConfigurationValue(data, "RemoteControlHostPath") is { Length: > 0 } path 
-					? path 
+				return GetConfigurationValue(data, "RemoteControlHostPath") is { Length: > 0 } path
+					? path
 					: throw new global::System.InvalidOperationException("Failed to get remote control host path");
 			}
 		}

--- a/src/Uno.UI.RuntimeTests.Engine.Library/Engine/UI/_Private/UnitTestDispatcherCompat.cs
+++ b/src/Uno.UI.RuntimeTests.Engine.Library/Engine/UI/_Private/UnitTestDispatcherCompat.cs
@@ -50,8 +50,8 @@ public partial class UnitTestDispatcherCompat
 
 #if WINDOWS_WINUI || HAS_UNO_WINUI
 
-    private readonly Windows.UI.Core.CoreDispatcher? _dispatcher;
-    public UnitTestDispatcherCompat(_Impl impl, Windows.UI.Core.CoreDispatcher? dispatcher = null)
+	private readonly Windows.UI.Core.CoreDispatcher? _dispatcher;
+	public UnitTestDispatcherCompat(_Impl impl, Windows.UI.Core.CoreDispatcher? dispatcher = null)
 	{
 		this._impl = impl;
 		this._dispatcher = dispatcher;

--- a/src/Uno.UI.RuntimeTests.Engine.Library/Engine/UnitTestClassInfo.cs
+++ b/src/Uno.UI.RuntimeTests.Engine.Library/Engine/UnitTestClassInfo.cs
@@ -22,7 +22,7 @@ public class UnitTestClassInfo
 	{
 		Type = type;
 		TestClassName = Type?.Name ?? "(null)";
-		Tests = tests ?? Array.Empty<MethodInfo>();
+		Tests = tests?.Select(test => new UnitTestMethodInfo(test)).ToArray() ?? Array.Empty<UnitTestMethodInfo>();
 		Initialize = initialize;
 		Cleanup = cleanup;
 
@@ -33,7 +33,7 @@ public class UnitTestClassInfo
 
 	public Type? Type { get; }
 
-	public MethodInfo[] Tests { get; }
+	public UnitTestMethodInfo[] Tests { get; }
 
 	public MethodInfo? Initialize { get; }
 

--- a/src/Uno.UI.RuntimeTests.Engine.Library/Engine/UnitTestMethodInfo.cs
+++ b/src/Uno.UI.RuntimeTests.Engine.Library/Engine/UnitTestMethodInfo.cs
@@ -17,12 +17,12 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Uno.UI.RuntimeTests;
 
-internal record UnitTestMethodInfo
+public record UnitTestMethodInfo
 {
 	private readonly List<ITestDataSource> _casesParameters;
 	private readonly IList<PointerDeviceType> _injectedPointerTypes;
 
-	public UnitTestMethodInfo(object testClassInstance, MethodInfo method)
+	public UnitTestMethodInfo(MethodInfo method)
 	{
 		Method = method;
 		RunsOnUIThread =
@@ -36,7 +36,7 @@ internal record UnitTestMethodInfo
 			.SingleOrDefault()
 			?.ExceptionType;
 
-		_casesParameters  = method
+		_casesParameters = method
 			.GetCustomAttributes()
 			.Where(x => x is ITestDataSource)
 			.Cast<ITestDataSource>()
@@ -80,7 +80,7 @@ internal record UnitTestMethodInfo
 		return false;
 	}
 
-	public IEnumerable<TestCase> GetCases(CancellationToken ct)
+	internal IEnumerable<TestCase> GetCases(CancellationToken ct)
 	{
 		List<TestCase> cases = new();
 
@@ -98,7 +98,7 @@ internal record UnitTestMethodInfo
 				.GetData(Method)
 				.Select(caseData => new TestCase
 				{
-					Parameters = caseData, 
+					Parameters = caseData,
 					DisplayName = testCaseSource.GetDisplayName(Method, caseData)
 				});
 


### PR DESCRIPTION
## Bugfix
Avoid secondary app init if test class has been ignored

## What is the current behavior?
WE init the secondary app to report ignore ... and test class fail on platform that does not support secondary app testing

## What is the new behavior?
🙃

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
