### PR TITLE
chore: Fix ambiguous log extension point of windows for uno

### DIFF
--- a/src/Uno.UI.RuntimeTests.Engine.Library/Library/Helpers/HotReloadHelper.cs
+++ b/src/Uno.UI.RuntimeTests.Engine.Library/Library/Helpers/HotReloadHelper.cs
@@ -58,7 +58,7 @@ public static partial class HotReloadHelper
 		global::System.Threading.Tasks.ValueTask<ReConnect?> Apply(FileEdit edition, global::System.Threading.CancellationToken ct);
 	}
 
-	private static readonly global::Microsoft.Extensions.Logging.ILogger _log = typeof(HotReloadHelper).Log();
+	private static readonly global::Microsoft.Extensions.Logging.ILogger _log = global::Uno.Extensions.LogExtensionPoint.Log(typeof(HotReloadHelper));
 	private static IFileUpdater _impl = new NotSupported();
 
 	/// <summary>


### PR DESCRIPTION
## Bugfix
Fix ambiguous log extension point of windows for uno

## What is the current behavior?
Uno does not compile with the runtime test package due to an ambiguous call to the log extension point

## What is the new behavior?
🙃

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
