### PR TITLE
fix: Disable dev-server package detection on windows

### DIFF
--- a/src/Uno.UI.RuntimeTests.Engine.Package/buildTransitive/Uno.UI.RuntimeTests.Engine.targets
+++ b/src/Uno.UI.RuntimeTests.Engine.Package/buildTransitive/Uno.UI.RuntimeTests.Engine.targets
@@ -1,6 +1,7 @@
 ﻿<Project>
-	<PropertyGroup Condition="'$(PkgUno_UI_DevServer)' != '' OR '$(PkgUno_WinUI_DevServer)' != ''">
-		<DefineConstants >$(DefineConstants);HAS_UNO_DEVSERVER</DefineConstants>
+	<!--Forcefull disable on windows as the package is actually empty on that target (no dev-server, we rely only on VS)-->
+	<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'windows' AND ('$(PkgUno_UI_DevServer)' != '' OR '$(PkgUno_WinUI_DevServer)' != '')">
+		<DefineConstants>$(DefineConstants);HAS_UNO_DEVSERVER</DefineConstants>
 		<UnoForceHotReloadCodeGen>true</UnoForceHotReloadCodeGen>
 		<UnoForceIncludeProjectConfiguration>true</UnoForceIncludeProjectConfiguration>
 		<UnoForceIncludeServerProcessorsConfiguration>true</UnoForceIncludeServerProcessorsConfiguration>


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno.ui.runtimetests.engine/issues/173

## Bugfix
Disable dev-server package detection on windows as package is empty on that target

## What is the current behavior?
Build fail on windows is including the runtime test package

## What is the new behavior?
Build succeed

## PR Checklist
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
