### PR TITLE
fix: add entry for msedge program files x86

### DIFF
--- a/src/Uno.UI.RuntimeTests.Engine.Wasm.Runner/Program.cs
+++ b/src/Uno.UI.RuntimeTests.Engine.Wasm.Runner/Program.cs
@@ -656,6 +656,7 @@ class Program
 			yield return @"C:\Program Files\Google\Chrome\Application\chrome.exe";
 			yield return @"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe";
 			yield return @"C:\Program Files\Microsoft\Edge\Application\msedge.exe";
+			yield return @"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe";
 		}
 		else if (OperatingSystem.IsMacOS())
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): #

https://github.com/unoplatform/uno.ui.runtimetests.engine/issues/201

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The runner does not find msedge when is installed in Program Files x86.

## What is the new behavior?

The runner finds msedge when is installed in Program Files x86.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
