### PR TITLE
fix: Read injected pointer button states reflectively (Uno 7.0 Microsoft.UI.Input)

### DIFF
--- a/src/Uno.UI.RuntimeTests.Engine.Library/Library/Helpers/InputInjectorHelper.MouseHelper.cs
+++ b/src/Uno.UI.RuntimeTests.Engine.Library/Library/Helpers/InputInjectorHelper.MouseHelper.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Windows.Foundation;
-using Windows.UI.Input;
 using Windows.UI.Input.Preview.Injection;
 
 namespace Uno.UI.RuntimeTests;
@@ -31,12 +30,17 @@ public partial class InputInjectorHelper
 				?? throw new NotSupportedException("This version of uno is not supported for pointer injection.");
 
 			CurrentPosition = () => (Point)getCurrentPosition.Invoke(getCurrent.Invoke(input, null)!, null)!;
-			CurrentProperties = () => (PointerPointProperties)getCurrentProperties.Invoke(getCurrent.Invoke(input, null)!, null)!;
+			// The pointer-point properties type moved from Windows.UI.Input to Microsoft.UI.Input in Uno 7.0;
+			// read the button states reflectively so the engine stays compatible with both namespaces.
+			CurrentProperties = () => getCurrentProperties.Invoke(getCurrent.Invoke(input, null)!, null)!;
 		}
 
-		private Func<PointerPointProperties> CurrentProperties;
+		private Func<object> CurrentProperties;
 
 		private Func<Point> CurrentPosition;
+
+		private static bool IsButtonPressed(object properties, string propertyName)
+			=> (bool)properties.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public)!.GetValue(properties)!;
 #else
 		private Point _trackedPosition;
 
@@ -77,22 +81,22 @@ public partial class InputInjectorHelper
 
 #if HAS_UNO
 			var currentProps = CurrentProperties();
-			if (currentProps.IsLeftButtonPressed)
+			if (IsButtonPressed(currentProps, "IsLeftButtonPressed"))
 			{
 				options |= InjectedInputMouseOptions.LeftUp;
 			}
 
-			if (currentProps.IsMiddleButtonPressed)
+			if (IsButtonPressed(currentProps, "IsMiddleButtonPressed"))
 			{
 				options |= InjectedInputMouseOptions.MiddleUp;
 			}
 
-			if (currentProps.IsRightButtonPressed)
+			if (IsButtonPressed(currentProps, "IsRightButtonPressed"))
 			{
 				options |= InjectedInputMouseOptions.RightUp;
 			}
 
-			if (currentProps.IsXButton1Pressed)
+			if (IsButtonPressed(currentProps, "IsXButton1Pressed"))
 			{
 				options |= InjectedInputMouseOptions.XUp;
 			}


### PR DESCRIPTION
## Problem

Uno 7.0 relocates the pointer-point types to `Microsoft.UI.Input` and drops the legacy `Windows.UI.Input.PointerPoint`/`PointerPointProperties` public surface (breaking-changes rollup). `InputInjectorHelper.MouseHelper` hard-casts the reflected mouse-properties object to `Windows.UI.Input.PointerPointProperties`, so the engine source no longer compiles against Uno 7.0 — this breaks any test fixture that references the engine (e.g. the `AlcApp`/`HRApp` fixtures in the main Uno repo), failing the ALC and HotReload runtime tests with `AlcApp build failed`.

## Fix

The properties object is already obtained via reflection. Read the button states (`IsLeftButtonPressed`, …) reflectively as well and drop the `using Windows.UI.Input;`, so the helper no longer has a compile-time dependency on either namespace's `PointerPointProperties`. This keeps the engine **source-compatible with both** the legacy (`Windows.UI.Input`) and new (`Microsoft.UI.Input`) Uno layouts — no behavioural change, values are identical.

## Notes

Needed to unblock the Uno 7.0 breaking-changes PR (unoplatform/uno#23619). Once this is published, that PR bumps the `Uno.UI.RuntimeTests.Engine` reference in the `AlcApp`/`HRApp` fixtures.